### PR TITLE
fix: case sensitivity in modify policy assignments

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,7 @@
 ---
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    - go mod vendor
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
@@ -19,6 +17,11 @@ archives:
       - goos: windows
         format: zip
 builds:
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
   - no_main_check: true
     skip: true
 checksum:
@@ -26,18 +29,26 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
+  disable: false
   sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "Doc updates"
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 999
   filters:
-    exclude:
+    include:
+      - "^feat:"
+      - "^fix:"
       - "^docs:"
-      - "^test:"
-      - "^ci:"
 release:
-  github:
-    name: alzlib
-    owner: matt-FFFFFF
-  header: |
-    # {{ .Tag }}
+  disable: false
 milestones:
   - close: true
 # The lines beneath this are called `modelines`. See `:help modeline`

--- a/alzmanagementgroup.go
+++ b/alzmanagementgroup.go
@@ -492,17 +492,17 @@ func modifyPolicyAssignments(alzmg *AlzManagementGroup, pd2mg, psd2mg map[string
 		// rewrite the referenced policy definition id
 		// if the policy definition is in the list.
 		pd := assignment.Properties.PolicyDefinitionID
-		switch lastButOneSegment(*pd) {
-		case "policyDefinitions":
+		switch strings.ToLower(lastButOneSegment(*pd)) {
+		case "policydefinitions":
 			if mgname, ok := pd2mg[lastSegment(*pd)]; ok {
 				assignment.Properties.PolicyDefinitionID = to.Ptr(fmt.Sprintf(policyDefinitionIdFmt, mgname, lastSegment(*pd)))
 			}
-		case "policySetDefinitions":
+		case "policysetdefinitions":
 			if mgname, ok := psd2mg[lastSegment(*pd)]; ok {
 				assignment.Properties.PolicyDefinitionID = to.Ptr(fmt.Sprintf(policySetDefinitionIdFmt, mgname, lastSegment(*pd)))
 			}
 		default:
-			return fmt.Errorf("policy assignment %s has invalid resource type in id %s", assignmentName, *pd)
+			return fmt.Errorf("policy assignment %s has invalid referenced definition/set resource type with id: %s", assignmentName, *pd)
 		}
 	}
 	return nil

--- a/alzmanagementgroup_test.go
+++ b/alzmanagementgroup_test.go
@@ -493,7 +493,7 @@ func TestModifyPolicyAssignments(t *testing.T) {
 	psd2mg = map[string]string{}
 	err = modifyPolicyAssignments(alzmg, pd2mg, psd2mg, papv)
 	assert.Error(t, err)
-	expected = "has invalid resource type in id"
+	expected = "has invalid referenced definition/set resource type with id"
 	assert.ErrorContains(t, err, expected)
 }
 

--- a/alzmanagementgroup_test.go
+++ b/alzmanagementgroup_test.go
@@ -23,7 +23,7 @@ import (
 func getRemoteLib(ctx context.Context) (fs.FS, error) {
 	q := url.Values{}
 	q.Add("depth", "1")
-	q.Add("ref", "main")
+	q.Add("ref", "platform/alz/2024.03.00")
 	u := "git::https://github.com/Azure/Azure-Landing-Zones-Library//platform/alz?" + q.Encode()
 	dst := filepath.Join(".alzlib", "lib")
 	if err := getter.Get(dst, u, getter.WithContext(ctx)); err != nil {


### PR DESCRIPTION
Fixes case where camel case is not correctly used for policy definition reference