### PR TITLE
fix: empty archetype already exists message

### DIFF
--- a/alzlib.go
+++ b/alzlib.go
@@ -479,13 +479,15 @@ func (az *AlzLib) addProcessedResult(res *processor.Result) error {
 // The archetypes are stored in the AlzLib instance.
 func (az *AlzLib) generateArchetypes(res *processor.Result) error {
 	// add empty archetype if it doesn't exist.
-	if _, exists := res.LibArchetypes["empty"]; !exists {
-		res.LibArchetypes["empty"] = &processor.LibArchetype{
-			Name:                 "empty",
-			PolicyAssignments:    mapset.NewThreadUnsafeSet[string](),
-			PolicyDefinitions:    mapset.NewThreadUnsafeSet[string](),
-			PolicySetDefinitions: mapset.NewThreadUnsafeSet[string](),
-			RoleDefinitions:      mapset.NewThreadUnsafeSet[string](),
+	if _, exists := az.archetypes["empty"]; !exists {
+		if _, exists := res.LibArchetypes["empty"]; !exists {
+			res.LibArchetypes["empty"] = &processor.LibArchetype{
+				Name:                 "empty",
+				PolicyAssignments:    mapset.NewThreadUnsafeSet[string](),
+				PolicyDefinitions:    mapset.NewThreadUnsafeSet[string](),
+				PolicySetDefinitions: mapset.NewThreadUnsafeSet[string](),
+				RoleDefinitions:      mapset.NewThreadUnsafeSet[string](),
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes bug when specifying more than one library, without having the `allow_lib_overwrite` enabled.