### PR TITLE
fix(alzlib): disable follow symlink for go-getter client

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,19 @@ checksum:
   name_template: "checksums.txt"
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
+archives:
+  - id: alzlibtool
+    format: tar.gz
+    builds:
+      - alzlibtool
+    name_template: "alzlibtool_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - format: zip
+        goos: windows
+    builds_info:
+      group: root
+      owner: root
+      mode: 0755
 changelog:
   sort: asc
   use: github

--- a/initialize.go
+++ b/initialize.go
@@ -82,7 +82,9 @@ func FetchAzureLandingZonesLibraryMember(ctx context.Context, path, ref, dstDir 
 func FetchLibraryByGetterString(ctx context.Context, getterString, dstDir string) (fs.FS, error) {
 	baseDir := environment.AlzLibDir()
 	dst := filepath.Join(baseDir, dstDir)
-	client := getter.Client{}
+	client := getter.Client{
+		DisableSymlinks: true,
+	}
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("FetchLibraryByGetterString: error getting working directory: %w", err)


### PR DESCRIPTION
In line with go-getter [security recommendations](https://pkg.go.dev/github.com/hashicorp/go-getter/v2#readme-security-options), disable symlink follow for getter client.

Also bonus tweak the release archive creation for a more predictable name.