### PR TITLE
feat!: add description to policy defaults

### DIFF
--- a/alzlib.go
+++ b/alzlib.go
@@ -264,14 +264,15 @@ func (az *AlzLib) PolicyDefaultValues() []string {
 	return result
 }
 
-func (az *AlzLib) PolicyDefaultValue(name string) DefaultPolicyAssignmentValuesValue {
+func (az *AlzLib) PolicyDefaultValue(name string) *DefaultPolicyAssignmentValuesValue {
 	az.mu.RLock()
 	defer az.mu.RUnlock()
 	val, ok := az.defaultPolicyAssignmentValues[name]
 	if !ok {
 		return nil
 	}
-	return val.copy()
+	ret := val.copy()
+	return &ret
 }
 
 // Architecture returns the requested architecture.
@@ -634,7 +635,7 @@ func (az *AlzLib) addDefaultPolicyAssignmentValues(res *processor.Result) error 
 					return fmt.Errorf("Alzlib.addDefaultPolicyValues: error processing default policy values for default name: `%s`, assignment `%s` and parameter `%s` already exists in defaults", defName, assignment.PolicyAssignmentName, param)
 				}
 			}
-			az.defaultPolicyAssignmentValues.Add(defName, assignment.PolicyAssignmentName, assignment.ParameterNames...)
+			az.defaultPolicyAssignmentValues.Add(defName, assignment.PolicyAssignmentName, def.Description, assignment.ParameterNames...)
 		}
 	}
 	return nil

--- a/alzlib_test.go
+++ b/alzlib_test.go
@@ -416,9 +416,9 @@ func TestAddDefaultPolicyValues(t *testing.T) {
 
 	// Check if the default policy values are added correctly
 	assert.Equal(t, 1, len(az.defaultPolicyAssignmentValues))
-	assert.Equal(t, 1, len(az.defaultPolicyAssignmentValues["default1"]))
-	assert.True(t, az.defaultPolicyAssignmentValues["default1"]["assignment1"].Contains("param1"))
-	assert.True(t, az.defaultPolicyAssignmentValues["default1"]["assignment1"].Contains("param2"))
+	assert.Equal(t, 1, len(az.defaultPolicyAssignmentValues["default1"].assignment2Parameters))
+	assert.True(t, az.defaultPolicyAssignmentValues["default1"].assignment2Parameters["assignment1"].Contains("param1"))
+	assert.True(t, az.defaultPolicyAssignmentValues["default1"].assignment2Parameters["assignment1"].Contains("param2"))
 	assert.True(t, az.defaultPolicyAssignmentValues.AssignmentParameterComboExists("assignment1", "param2"))
 
 	res = &processor.Result{

--- a/defaultPolicyAssignmentValues_test.go
+++ b/defaultPolicyAssignmentValues_test.go
@@ -12,12 +12,18 @@ import (
 func TestDefaultPolicyAssignmentValues_AssignmentParameterComboExists(t *testing.T) {
 	d := DefaultPolicyAssignmentValues{
 		"Default1": DefaultPolicyAssignmentValuesValue{
-			"Assignment1": mapset.NewSet("Parameter1", "Parameter2"),
-			"Assignment2": mapset.NewSet("Parameter3", "Parameter4"),
+			assignment2Parameters: map[string]mapset.Set[string]{
+				"Assignment1": mapset.NewSet("Parameter1", "Parameter2"),
+				"Assignment2": mapset.NewSet("Parameter3", "Parameter4"),
+			},
+			description: "",
 		},
 		"Default2": DefaultPolicyAssignmentValuesValue{
-			"Assignment3": mapset.NewSet("Parameter5", "Parameter6"),
-			"Assignment4": mapset.NewSet("Parameter7", "Parameter8"),
+			assignment2Parameters: map[string]mapset.Set[string]{
+				"Assignment3": mapset.NewSet("Parameter5", "Parameter6"),
+				"Assignment4": mapset.NewSet("Parameter7", "Parameter8"),
+			},
+			description: "",
 		},
 	}
 
@@ -48,20 +54,20 @@ func TestDefaultPolicyAssignmentValues_Add(t *testing.T) {
 	d := DefaultPolicyAssignmentValues{}
 
 	// Test adding a new default name and assignment name
-	d.Add("Default1", "Assignment1", "Parameter1", "Parameter2")
+	d.Add("Default1", "Assignment1", "", "Parameter1", "Parameter2")
 	if !d.AssignmentParameterComboExists("Assignment1", "Parameter1") {
 		t.Error("Failed to add assignment and parameter to DefaultPolicyAssignmentValues")
 	}
 
 	// Test adding a new assignment name under an existing default name
-	d.Add("Default1", "Assignment2", "Parameter3", "Parameter4")
+	d.Add("Default1", "Assignment2", "", "Parameter3", "Parameter4")
 	if !d.AssignmentParameterComboExists("Assignment2", "Parameter3") {
 		t.Error("Failed to add assignment and parameter to DefaultPolicyAssignmentValues")
 	}
 
 	// Test adding a new default name with multiple assignments and parameters
-	d.Add("Default2", "Assignment3", "Parameter5", "Parameter6")
-	d.Add("Default2", "Assignment4", "Parameter7", "Parameter8")
+	d.Add("Default2", "Assignment3", "", "Parameter5", "Parameter6")
+	d.Add("Default2", "Assignment4", "", "Parameter7", "Parameter8")
 	if !d.AssignmentParameterComboExists("Assignment3", "Parameter5") || !d.AssignmentParameterComboExists("Assignment4", "Parameter8") {
 		t.Error("Failed to add assignments and parameters to DefaultPolicyAssignmentValues")
 	}

--- a/deployment/hierarchy.go
+++ b/deployment/hierarchy.go
@@ -119,7 +119,7 @@ func (h *Hierarchy) AddDefaultPolicyAssignmentValue(ctx context.Context, default
 	}
 	// Get the policy assignments for each management group.
 	for _, mg := range h.mgs {
-		for assignment, params := range defs {
+		for assignment, params := range defs.PolicyAssignment2ParameterMap() {
 			if _, ok := mg.policyAssignments[assignment]; !ok {
 				continue
 			}

--- a/deployment/hierarchy_test.go
+++ b/deployment/hierarchy_test.go
@@ -154,8 +154,7 @@ func TestAddDefaultPolicyAssignmentValue(t *testing.T) {
 	defaults := defaultsPtr.Interface().(alzlib.DefaultPolicyAssignmentValues) //nolint:forcetypeassert
 
 	t.Run("Default param present in definition", func(t *testing.T) {
-		defaults["default"] = make(alzlib.DefaultPolicyAssignmentValuesValue)
-		defaults["default"]["pa1"] = mapset.NewThreadUnsafeSet("param1")
+		defaults.Add("default", "pa1", "", "param1")
 		// Define the default policy assignment value.
 		defaultName := "default"
 		defaultValue := &armpolicy.ParameterValuesValue{Value: to.Ptr("value1")}
@@ -167,7 +166,7 @@ func TestAddDefaultPolicyAssignmentValue(t *testing.T) {
 	})
 
 	t.Run("Default parameter not present in definition", func(t *testing.T) {
-		defaults["default"]["pa1"] = mapset.NewThreadUnsafeSet("param4")
+		defaults.Add("default", "pa1", "", "param4")
 		defaultName := "default"
 		defaultValue := &armpolicy.ParameterValuesValue{Value: to.Ptr("value1")}
 		// Add the default policy assignment value to the hierarchy.

--- a/internal/doc/doc.go
+++ b/internal/doc/doc.go
@@ -226,11 +226,18 @@ func alzlibReadmeMdPolicyDefaultValues(md *markdown.Markdown, az *alzlib.AlzLib)
 	md = md.H2("Policy Default Values").LF().PlainText("The following policy default values are available in this library:").LF()
 	for _, pdv := range pdvs {
 		md = md.H3("default name `" + pdv + "`").LF()
-		for _, assignment := range az.PolicyDefaultValue(pdv).Assignments() {
-			params := az.PolicyDefaultValue(pdv).AssignmentParameters(assignment)
-			md = md.H4("assignment `"+assignment+"`").LF().
-				Details(fmt.Sprintf("%d parameter names", len(params)), "\n- "+strings.Join(params, "\n- ")).LF()
+		desc := az.PolicyDefaultValue(pdv).Description()
+		if desc != "" {
+			md = md.PlainText(desc).LF()
 		}
+		t := markdown.TableSet{
+			Header: []string{"Assignment", "Parameter Names"},
+			Rows:   [][]string{},
+		}
+		for _, assignment := range az.PolicyDefaultValue(pdv).Assignments() {
+			t.Rows = append(t.Rows, []string{assignment, strings.Join(az.PolicyDefaultValue(pdv).AssignmentParameters(assignment), ", ")})
+		}
+		md = md.Table(t).LF()
 	}
 	return md
 }

--- a/internal/processor/libDefaultpolicyValues.go
+++ b/internal/processor/libDefaultpolicyValues.go
@@ -10,6 +10,7 @@ type LibDefaultPolicyValues struct {
 // LibDefaultPolicyValues represents the default policy values that allow a single value to be mapped into different assignments.
 type LibDefaultPolicyValuesDefaults struct {
 	DefaultName       string                             `json:"default_name" yaml:"default_name"`
+	Description       string                             `json:"description,omitempty" yaml:"description"`
 	PolicyAssignments []LibDefaultPolicyValueAssignments `json:"policy_assignments" yaml:"policy_assignments"`
 }
 


### PR DESCRIPTION
Adds description field to policy default values. Modifies documentation output to tabular format and include description when available.

Example output:


## Policy Default Values

The following policy default values are available in this library:

### default name `ama_change_tracking_data_collection_rule_id`

The data collection rule id that should be used for the change tracking deployment.

|        ASSIGNMENT        | PARAMETER NAMES |
|--------------------------|-----------------|
| Deploy-VM-ChangeTrack    | dcrResourceId   |
| Deploy-VMSS-ChangeTrack  | dcrResourceId   |
| Deploy-vmArc-ChangeTrack | dcrResourceId   |


### default name `ama_mdfc_sql_data_collection_rule_id`

The data collection rule id that should be used for the SQL MDFC deployment.

|       ASSIGNMENT       | PARAMETER NAMES |
|------------------------|-----------------|
| Deploy-MDFC-DefSQL-AMA | dcrResourceId   |