### PR TITLE
fix: collect and emit sensible errors when unable to determine correct policy role assignment scopes

### DIFF
--- a/deployment/hierarchy.go
+++ b/deployment/hierarchy.go
@@ -98,6 +98,8 @@ func (h *Hierarchy) FromArchitecture(ctx context.Context, arch, externalParentId
 }
 
 // PolicyAssignments returns the policy assignments required for the hierarchy.
+// This error returned bay be a PolicyAssignmentErrors, which contains a slice of errors.
+// This is so that callers can choose to issue a warning here instead of halting the process.
 func (h *Hierarchy) PolicyRoleAssignments(ctx context.Context) (mapset.Set[PolicyRoleAssignment], error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/deployment/hierarchy.go
+++ b/deployment/hierarchy.go
@@ -120,7 +120,10 @@ func (h *Hierarchy) PolicyRoleAssignments(ctx context.Context) (mapset.Set[Polic
 		}
 		res = res.Union(mg.policyRoleAssignments)
 	}
-	return res, errs
+	if errs != nil {
+		return res, errs
+	}
+	return res, nil
 }
 
 // AddDefaultPolicyAssignmentValue adds a default policy assignment value to the hierarchy.

--- a/deployment/managementgroup.go
+++ b/deployment/managementgroup.go
@@ -159,6 +159,9 @@ func (alzmg *HierarchyManagementGroup) RoleDefinitionsMap() map[string]*assets.R
 // It will iterate through all policy assignments and generate the additional role assignments for each one,
 // storing them in the AdditionalRoleAssignmentsByPolicyAssignment map.
 func (mg *HierarchyManagementGroup) generatePolicyAssignmentAdditionalRoleAssignments() error {
+	// Make a error collection type so we can return them in the error message without stopping the process.
+	// Upstream code can then decide what to do with them, issue warnings in stead of hard fail, etc.
+	var errs *PolicyRoleAssignmentErrors
 	for paName, pa := range mg.policyAssignments {
 		// we only care about policy assignments that use an identity
 		if pa.IdentityType() == armpolicy.ResourceIdentityTypeNone {
@@ -288,7 +291,10 @@ func (mg *HierarchyManagementGroup) generatePolicyAssignmentAdditionalRoleAssign
 					// extract the assignment exposed policy set parameter name from the ARM function used in the policy definition reference
 					paParamName, err := extractParameterNameFromArmFunction(pdrefParamValStr)
 					if err != nil {
-						return fmt.Errorf("ManagementGroup.GeneratePolicyAssignmentAdditionalRoleAssignments: error extracting parameter name from ARM function `%s`: %w", pdrefParamValStr, err)
+						if errs == nil {
+							errs = NewPolicyRoleAssignmentErrors()
+						}
+						errs.Add(NewPolicyRoleAssignmentError(paName, mg.id, paramName, *pdRef.PolicyDefinitionReferenceID, rdids))
 					}
 
 					// if the parameter in the assignment doesn't exist, skip it
@@ -312,7 +318,7 @@ func (mg *HierarchyManagementGroup) generatePolicyAssignmentAdditionalRoleAssign
 			}
 		}
 	}
-	return nil
+	return errs
 }
 
 // update will update the AlzManagementGroup resources with the correct resource ids, references, etc.

--- a/deployment/managementgroup.go
+++ b/deployment/managementgroup.go
@@ -318,7 +318,10 @@ func (mg *HierarchyManagementGroup) generatePolicyAssignmentAdditionalRoleAssign
 			}
 		}
 	}
-	return errs
+	if errs != nil {
+		return errs
+	}
+	return nil
 }
 
 // update will update the AlzManagementGroup resources with the correct resource ids, references, etc.

--- a/deployment/policyRoleAssignmentError.go
+++ b/deployment/policyRoleAssignmentError.go
@@ -62,7 +62,7 @@ func (e *PolicyRoleAssignmentErrors) Error() string {
 	for i, err := range e.errors {
 		errors[i] = err.Error()
 	}
-	return strings.Join(errors, "\n")
+	return strings.Join(errors, "\n---\n")
 }
 
 // Errors returns the collection of PolicyRoleAssignmentError.

--- a/deployment/policyRoleAssignmentError.go
+++ b/deployment/policyRoleAssignmentError.go
@@ -8,6 +8,7 @@ import (
 var _ error = &PolicyRoleAssignmentError{}
 var _ error = &PolicyRoleAssignmentErrors{}
 
+// PolicyRoleAssignmentError represents an error that occurred while generating a role assignment for a policy assignment.
 type PolicyRoleAssignmentError struct {
 	assignmentName            string
 	assignmentScope           string
@@ -16,6 +17,8 @@ type PolicyRoleAssignmentError struct {
 	roleDefinitionIds         []string
 }
 
+// PolicyRoleAssignmentErrors represents a collection of PolicyRoleAssignmentError.
+// It can be used by the caller to emit a warning rather than halt execution.
 type PolicyRoleAssignmentErrors struct {
 	errors []*PolicyRoleAssignmentError
 }
@@ -36,6 +39,7 @@ func NewPolicyRoleAssignmentErrors() *PolicyRoleAssignmentErrors {
 	return e
 }
 
+// Error implements the error interface.
 func (e *PolicyRoleAssignmentError) Error() string {
 	return fmt.Sprintf(
 		"PolicyRoleAssignmentError: could not generate role assignment for assignment `%s` assigned at scope `%s`. A new role assignment should be created at scope of the definition referenced by `%s`, using parameter name `%s`, for the following role definition ids: `%s`",
@@ -47,10 +51,12 @@ func (e *PolicyRoleAssignmentError) Error() string {
 	)
 }
 
+// Add adds one or more PolicyRoleAssignmentError to the collection.
 func (e *PolicyRoleAssignmentErrors) Add(err ...*PolicyRoleAssignmentError) {
 	e.errors = append(e.errors, err...)
 }
 
+// Error implements the error interface.
 func (e *PolicyRoleAssignmentErrors) Error() string {
 	errors := make([]string, len(e.errors))
 	for i, err := range e.errors {
@@ -59,6 +65,7 @@ func (e *PolicyRoleAssignmentErrors) Error() string {
 	return strings.Join(errors, "\n")
 }
 
+// Errors returns the collection of PolicyRoleAssignmentError.
 func (e *PolicyRoleAssignmentErrors) Errors() []*PolicyRoleAssignmentError {
 	return e.errors
 }

--- a/deployment/policyRoleAssignmentError.go
+++ b/deployment/policyRoleAssignmentError.go
@@ -1,0 +1,64 @@
+package deployment
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ error = &PolicyRoleAssignmentError{}
+var _ error = &PolicyRoleAssignmentErrors{}
+
+type PolicyRoleAssignmentError struct {
+	assignmentName            string
+	assignmentScope           string
+	definitionParameterName   string
+	policyDefinitionReference string
+	roleDefinitionIds         []string
+}
+
+type PolicyRoleAssignmentErrors struct {
+	errors []*PolicyRoleAssignmentError
+}
+
+func NewPolicyRoleAssignmentError(assignmentName string, assignmentScope string, defParameterName string, pdref string, roleDefinitionIds []string) *PolicyRoleAssignmentError {
+	return &PolicyRoleAssignmentError{
+		assignmentName:            assignmentName,
+		assignmentScope:           assignmentScope,
+		definitionParameterName:   defParameterName,
+		policyDefinitionReference: pdref,
+		roleDefinitionIds:         roleDefinitionIds,
+	}
+}
+
+func NewPolicyRoleAssignmentErrors() *PolicyRoleAssignmentErrors {
+	e := new(PolicyRoleAssignmentErrors)
+	e.errors = make([]*PolicyRoleAssignmentError, 0)
+	return e
+}
+
+func (e *PolicyRoleAssignmentError) Error() string {
+	return fmt.Sprintf(
+		"PolicyRoleAssignmentError: could not generate role assignment for assignment `%s` assigned at scope `%s`. A new role assignment should be created at scope of the definition referenced by `%s`, using parameter name `%s`, for the following role definition ids: `%s`",
+		e.assignmentName,
+		e.assignmentScope,
+		e.policyDefinitionReference,
+		e.definitionParameterName,
+		strings.Join(e.roleDefinitionIds, ", "),
+	)
+}
+
+func (e *PolicyRoleAssignmentErrors) Add(err ...*PolicyRoleAssignmentError) {
+	e.errors = append(e.errors, err...)
+}
+
+func (e *PolicyRoleAssignmentErrors) Error() string {
+	errors := make([]string, len(e.errors))
+	for i, err := range e.errors {
+		errors[i] = err.Error()
+	}
+	return strings.Join(errors, "\n")
+}
+
+func (e *PolicyRoleAssignmentErrors) Errors() []*PolicyRoleAssignmentError {
+	return e.errors
+}

--- a/deployment/policyRoleAssignmentError_test.go
+++ b/deployment/policyRoleAssignmentError_test.go
@@ -29,7 +29,7 @@ func TestPolicyRoleAssignmentErrors_Add(t *testing.T) {
 	errors.Add(err1)
 	errors.Add(err2)
 
-	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\n---\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
 	if errors.Error() != expected {
 		t.Errorf("expected %s, got %s", expected, errors.Error())
 	}

--- a/deployment/policyRoleAssignmentError_test.go
+++ b/deployment/policyRoleAssignmentError_test.go
@@ -29,7 +29,7 @@ func TestPolicyRoleAssignmentErrors_Add(t *testing.T) {
 	errors.Add(err1)
 	errors.Add(err2)
 
-	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope `testParameter1` for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope `testParameter2` for the following role definition ids: `role3, role4`"
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
 	if errors.Error() != expected {
 		t.Errorf("expected %s, got %s", expected, errors.Error())
 	}

--- a/deployment/policyRoleAssignmentError_test.go
+++ b/deployment/policyRoleAssignmentError_test.go
@@ -15,7 +15,7 @@ func TestPolicyRoleAssignmentErrors_Error(t *testing.T) {
 	err2 := NewPolicyRoleAssignmentError("testAssignment2", "testScope2", "testParameter2", "pdRef2", []string{"role3", "role4"})
 	errors := PolicyRoleAssignmentErrors{
 		errors: []*PolicyRoleAssignmentError{err1, err2}}
-	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\n---\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
 	if errors.Error() != expected {
 		t.Errorf("expected %s, got %s", expected, errors.Error())
 	}

--- a/deployment/policyRoleAssignmentError_test.go
+++ b/deployment/policyRoleAssignmentError_test.go
@@ -1,0 +1,36 @@
+package deployment
+
+import "testing"
+
+func TestPolicyRoleAssignmentError_Error(t *testing.T) {
+	err := NewPolicyRoleAssignmentError("testAssignment", "testScope", "testParameter", "pdRef1", []string{"role1", "role2"})
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment` assigned at scope `testScope`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter`, for the following role definition ids: `role1, role2`"
+	if err.Error() != expected {
+		t.Errorf("expected %s, got %s", expected, err.Error())
+	}
+}
+
+func TestPolicyRoleAssignmentErrors_Error(t *testing.T) {
+	err1 := NewPolicyRoleAssignmentError("testAssignment1", "testScope1", "testParameter1", "pdRef1", []string{"role1", "role2"})
+	err2 := NewPolicyRoleAssignmentError("testAssignment2", "testScope2", "testParameter2", "pdRef2", []string{"role3", "role4"})
+	errors := PolicyRoleAssignmentErrors{
+		errors: []*PolicyRoleAssignmentError{err1, err2}}
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope of the definition referenced by `pdRef1`, using parameter name `testParameter1`, for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope of the definition referenced by `pdRef2`, using parameter name `testParameter2`, for the following role definition ids: `role3, role4`"
+	if errors.Error() != expected {
+		t.Errorf("expected %s, got %s", expected, errors.Error())
+	}
+}
+
+func TestPolicyRoleAssignmentErrors_Add(t *testing.T) {
+	errors := NewPolicyRoleAssignmentErrors()
+	err1 := NewPolicyRoleAssignmentError("testAssignment1", "testScope1", "testParameter1", "pdRef1", []string{"role1", "role2"})
+	err2 := NewPolicyRoleAssignmentError("testAssignment2", "testScope2", "testParameter2", "pdRef2", []string{"role3", "role4"})
+
+	errors.Add(err1)
+	errors.Add(err2)
+
+	expected := "PolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment1` assigned at scope `testScope1`. A new role assignment should be created at scope `testParameter1` for the following role definition ids: `role1, role2`\nPolicyRoleAssignmentError: could not generate role assignment for assignment `testAssignment2` assigned at scope `testScope2`. A new role assignment should be created at scope `testParameter2` for the following role definition ids: `role3, role4`"
+	if errors.Error() != expected {
+		t.Errorf("expected %s, got %s", expected, errors.Error())
+	}
+}

--- a/integrationtest/examples_test.go
+++ b/integrationtest/examples_test.go
@@ -6,7 +6,6 @@ package integrationtest
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/Azure/alzlib"
 	"github.com/Azure/alzlib/deployment"
@@ -30,7 +29,6 @@ func Example_deploymentNewHierarchy() {
 		return
 	}
 	az.AddPolicyClient(cf)
-	//dirFs, err := alzlib.FetchAzureLandingZonesLibraryMember(ctx, alzLibraryMember, alzLibraryTag, "alz")
 	lib := alzlib.NewCustomLibraryReference("testdata/alzlib-2024-07-01")
 	libs, err := lib.FetchWithDependencies(ctx)
 	if err != nil {
@@ -54,7 +52,6 @@ func Example_deploymentNewHierarchy() {
 		return
 	}
 	mgs := h.ManagementGroupNames()
-	slices.Sort(mgs)
 	fmt.Println("Management groups:", mgs)
 
 	// Output:

--- a/integrationtest/testdata/policydefaultscomplexfunc/Deploy-Private-DNS-Zones.alz_policy_assignment.json
+++ b/integrationtest/testdata/policydefaultscomplexfunc/Deploy-Private-DNS-Zones.alz_policy_assignment.json
@@ -1,0 +1,226 @@
+{
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2022-06-01",
+  "name": "Deploy-Private-DNS-Zones",
+  "location": "${default_location}",
+  "dependsOn": [],
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "properties": {
+    "description": "This policy initiative is a group of policies that ensures private endpoints to Azure PaaS services are integrated with Azure Private DNS zones",
+    "displayName": "Configure Azure PaaS services to use private DNS zones",
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/Deploy-Private-DNS-Zones",
+    "enforcementMode": "Default",
+    "nonComplianceMessages": [
+      {
+        "message": "Azure PaaS services {enforcementMode} use private DNS zones."
+      }
+    ],
+    "parameters": {
+      "azureFilePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.afs.azure.net"
+      },
+      "azureAutomationWebhookPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azure-automation.net"
+      },
+      "azureAutomationDSCHybridPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azure-automation.net"
+      },
+      "azureCosmosSQLPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.documents.azure.com"
+      },
+      "azureCosmosMongoPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.mongo.cosmos.azure.com"
+      },
+      "azureCosmosCassandraPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.cassandra.cosmos.azure.com"
+      },
+      "azureCosmosGremlinPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.gremlin.cosmos.azure.com"
+      },
+      "azureCosmosTablePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.table.cosmos.azure.com"
+      },
+      "azureDataFactoryPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.datafactory.azure.net"
+      },
+      "azureDataFactoryPortalPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.adf.azure.com"
+      },
+      "azureDatabricksPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azuredatabricks.net"
+      },
+      "azureHDInsightPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azurehdinsight.net"
+      },
+      "azureMigratePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.prod.migration.windowsazure.com"
+      },
+      "azureStorageBlobPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+      },
+      "azureStorageBlobSecPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+      },
+      "azureStorageQueuePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.queue.core.windows.net"
+      },
+      "azureStorageQueueSecPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.queue.core.windows.net"
+      },
+      "azureStorageFilePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.file.core.windows.net"
+      },
+      "azureStorageStaticWebPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.web.core.windows.net"
+      },
+      "azureStorageStaticWebSecPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.web.core.windows.net"
+      },
+      "azureStorageDFSPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.dfs.core.windows.net"
+      },
+      "azureStorageDFSSecPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.dfs.core.windows.net"
+      },
+      "azureSynapseSQLPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.sql.azuresynapse.net"
+      },
+      "azureSynapseSQLODPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.sql.azuresynapse.net"
+      },
+      "azureSynapseDevPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.dev.azuresynapse.net"
+      },
+      "azureMediaServicesKeyPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.media.azure.net"
+      },
+      "azureMediaServicesLivePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.media.azure.net"
+      },
+      "azureMediaServicesStreamPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.media.azure.net"
+      },
+      "azureMonitorPrivateDnsZoneId1": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.monitor.azure.com"
+      },
+      "azureMonitorPrivateDnsZoneId2": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.oms.opinsights.azure.com"
+      },
+      "azureMonitorPrivateDnsZoneId3": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.ods.opinsights.azure.com"
+      },
+      "azureMonitorPrivateDnsZoneId4": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.agentsvc.azure-automation.net"
+      },
+      "azureMonitorPrivateDnsZoneId5": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+      },
+      "azureWebPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com"
+      },
+      "azureBatchPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com"
+      },
+      "azureAppPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azconfig.io"
+      },
+      "azureAsrPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.siterecovery.windowsazure.com"
+      },
+      "azureIotPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azure-devices-provisioning.net"
+      },
+      "azureKeyVaultPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
+      },
+      "azureSignalRPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.service.signalr.net"
+      },
+      "azureAppServicesPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azurewebsites.net"
+      },
+      "azureEventGridTopicsPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.eventgrid.azure.net"
+      },
+      "azureDiskAccessPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+      },
+      "azureCognitiveServicesPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.cognitiveservices.azure.com"
+      },
+      "azureIotHubsPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azure-devices.net"
+      },
+      "azureEventGridDomainsPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.eventgrid.azure.net"
+      },
+      "azureRedisCachePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.redis.cache.windows.net"
+      },
+      "azureAcrPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"
+      },
+      "azureEventHubNamespacePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.servicebus.windows.net"
+      },
+      "azureMachineLearningWorkspacePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.api.azureml.ms"
+      },
+      "azureMachineLearningWorkspaceSecondPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.notebooks.azure.net"
+      },
+      "azureServiceBusNamespacePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.servicebus.windows.net"
+      },
+      "azureCognitiveSearchPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.search.windows.net"
+      },
+      "azureBotServicePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.directline.botframework.com"
+      },
+      "azureManagedGrafanaWorkspacePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.grafana.azure.com"
+      },
+      "azureVirtualDesktopHostpoolPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.wvd.microsoft.com"
+      },
+      "azureVirtualDesktopWorkspacePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.wvd.microsoft.com"
+      },
+      "azureIotDeviceupdatePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azure-devices.net"
+      },
+      "azureArcGuestconfigurationPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.guestconfiguration.azure.com"
+      },
+      "azureArcHybridResourceProviderPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.his.arc.azure.com"
+      },
+      "azureArcKubernetesConfigurationPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.dp.kubernetesconfiguration.azure.com"
+      },
+      "azureIotCentralPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.azureiotcentral.com"
+      },
+      "azureStorageTablePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.table.core.windows.net"
+      },
+      "azureStorageTableSecondaryPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.table.core.windows.net"
+      },
+      "azureSiteRecoveryBackupPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.ne.backup.windowsazure.com"
+      },
+      "azureSiteRecoveryBlobPrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+      },
+      "azureSiteRecoveryQueuePrivateDnsZoneId": {
+        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones//providers/Microsoft.Network/privateDnsZones/privatelink.queue.core.windows.net"
+      }
+    },
+    "scope": "/providers/Microsoft.Management/managementGroups/placeholder",
+    "notScopes": []
+  }
+}

--- a/integrationtest/testdata/policydefaultscomplexfunc/Deploy-Provate-DNS-Zones.alz_policy_set_definition.json
+++ b/integrationtest/testdata/policydefaultscomplexfunc/Deploy-Provate-DNS-Zones.alz_policy_set_definition.json
@@ -1,0 +1,1674 @@
+{
+  "name": "Deploy-Private-DNS-Zones",
+  "properties": {
+    "description": "This policy initiative is a group of policies that ensures private endpoints to Azure PaaS services are integrated with Azure Private DNS zones",
+    "displayName": "Configure Azure PaaS services to use private DNS zones",
+    "metadata": {
+      "alzCloudEnvironments": [
+        "AzureCloud"
+      ],
+      "category": "Network",
+      "source": "https://github.com/Azure/Enterprise-Scale/",
+      "version": "2.3.0"
+    },
+    "parameters": {
+      "azureAcrPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAcrPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureAppPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAppPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureAppServicesPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAppServicesPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureArcGuestconfigurationPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureArcGuestconfigurationPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureArcHybridResourceProviderPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureArcHybridResourceProviderPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureArcKubernetesConfigurationPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureArcKubernetesConfigurationPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureAsrPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAsrPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureAutomationDSCHybridPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAutomationDSCHybridPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureAutomationWebhookPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureAutomationWebhookPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureBatchPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureBatchPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureBotServicePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureBotServicePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCognitiveSearchPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCognitiveSearchPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCognitiveServicesPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCognitiveServicesPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCosmosCassandraPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCosmosCassandraPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCosmosGremlinPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCosmosGremlinPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCosmosMongoPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCosmosMongoPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCosmosSQLPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCosmosSQLPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureCosmosTablePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureCosmosTablePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureDataFactoryPortalPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureDataFactoryPortalPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureDataFactoryPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureDataFactoryPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureDatabricksPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureDatabricksPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureDiskAccessPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureDiskAccessPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureEventGridDomainsPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureEventGridDomainsPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureEventGridTopicsPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureEventGridTopicsPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureEventHubNamespacePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureEventHubNamespacePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureFilePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureFilePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureHDInsightPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureHDInsightPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureIotCentralPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureIotCentralPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureIotDeviceupdatePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureIotDeviceupdatePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureIotHubsPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureIotHubsPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureIotPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureIotPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureKeyVaultPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureKeyVaultPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMachineLearningWorkspacePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMachineLearningWorkspacePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMachineLearningWorkspaceSecondPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMachineLearningWorkspaceSecondPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureManagedGrafanaWorkspacePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureManagedGrafanaWorkspacePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMediaServicesKeyPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMediaServicesKeyPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMediaServicesLivePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMediaServicesLivePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMediaServicesStreamPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMediaServicesStreamPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMigratePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMigratePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMonitorPrivateDnsZoneId1": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMonitorPrivateDnsZoneId1",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMonitorPrivateDnsZoneId2": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMonitorPrivateDnsZoneId2",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMonitorPrivateDnsZoneId3": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMonitorPrivateDnsZoneId3",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMonitorPrivateDnsZoneId4": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMonitorPrivateDnsZoneId4",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureMonitorPrivateDnsZoneId5": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureMonitorPrivateDnsZoneId5",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureRedisCachePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureRedisCachePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureServiceBusNamespacePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureServiceBusNamespacePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSignalRPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSignalRPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSiteRecoveryBackupPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSiteRecoveryBackupPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSiteRecoveryBlobPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSiteRecoveryBlobPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSiteRecoveryQueuePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSiteRecoveryQueuePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageBlobPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageBlobPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageBlobSecPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageBlobSecPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageDFSPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageDFSPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageDFSSecPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageDFSSecPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageFilePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageFilePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageQueuePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageQueuePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageQueueSecPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageQueueSecPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageStaticWebPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageStaticWebPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageStaticWebSecPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageStaticWebSecPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageTablePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageTablePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureStorageTableSecondaryPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureStorageTableSecondaryPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSynapseDevPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSynapseDevPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSynapseSQLODPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSynapseSQLODPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureSynapseSQLPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureSynapseSQLPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureVirtualDesktopHostpoolPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureVirtualDesktopHostpoolPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureVirtualDesktopWorkspacePrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureVirtualDesktopWorkspacePrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "azureWebPrivateDnsZoneId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "Private DNS Zone Identifier",
+          "displayName": "azureWebPrivateDnsZoneId",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        },
+        "type": "string"
+      },
+      "dnsZoneNames": {
+        "defaultValue": {
+          "azureAcrDataPrivateDnsZoneId": "{regionName}.data.privatelink.azurecr.io",
+          "azureAcrPrivateDnsZoneId": "privatelink.azurecr.io",
+          "azureAppPrivateDnsZoneId": "privatelink.azconfig.io",
+          "azureAppServicesPrivateDnsZoneId": "privatelink.azurewebsites.net",
+          "azureArcGuestconfigurationPrivateDnsZoneId": "privatelink.guestconfiguration.azure.com",
+          "azureArcHybridResourceProviderPrivateDnsZoneId": "privatelink.his.arc.azure.com",
+          "azureArcKubernetesConfigurationPrivateDnsZoneId": "privatelink.dp.kubernetesconfiguration.azure.com",
+          "azureAsrPrivateDnsZoneId": "privatelink.siterecovery.windowsazure.com",
+          "azureAutomationDSCHybridPrivateDnsZoneId": "privatelink.azure-automation.net",
+          "azureAutomationWebhookPrivateDnsZoneId": "privatelink.azure-automation.net",
+          "azureBatchPrivateDnsZoneId": "privatelink.batch.azure.com",
+          "azureBotServicePrivateDnsZoneId": "privatelink.directline.botframework.com",
+          "azureCognitiveSearchPrivateDnsZoneId": "privatelink.search.windows.net",
+          "azureCognitiveServicesPrivateDnsZoneId": "privatelink.cognitiveservices.azure.com",
+          "azureCosmosCassandraPrivateDnsZoneId": "privatelink.cassandra.cosmos.azure.com",
+          "azureCosmosGremlinPrivateDnsZoneId": "privatelink.gremlin.cosmos.azure.com",
+          "azureCosmosMongoPrivateDnsZoneId": "privatelink.mongo.cosmos.azure.com",
+          "azureCosmosSQLPrivateDnsZoneId": "privatelink.documents.azure.com",
+          "azureCosmosTablePrivateDnsZoneId": "privatelink.table.cosmos.azure.com",
+          "azureDataExplorerPrivateDnsZoneId": "privatelink.{regionName}.kusto.windows.net",
+          "azureDataFactoryPortalPrivateDnsZoneId": "privatelink.adf.azure.com",
+          "azureDataFactoryPrivateDnsZoneId": "privatelink.datafactory.azure.net",
+          "azureDatabricksPrivateDnsZoneId": "privatelink.azuredatabricks.net",
+          "azureDiskAccessPrivateDnsZoneId": "privatelink.blob.core.windows.net",
+          "azureEventGridDomainsPrivateDnsZoneId": "privatelink.eventgrid.azure.net",
+          "azureEventGridTopicsPrivateDnsZoneId": "privatelink.eventgrid.azure.net",
+          "azureEventHubNamespacePrivateDnsZoneId": "privatelink.servicebus.windows.net",
+          "azureFilePrivateDnsZoneId": "privatelink.afs.azure.net",
+          "azureHDInsightPrivateDnsZoneId": "privatelink.azurehdinsight.net",
+          "azureIotCentralPrivateDnsZoneId": "privatelink.azureiotcentral.com",
+          "azureIotDeviceupdatePrivateDnsZoneId": "privatelink.azure-devices.net",
+          "azureIotHubsPrivateDnsZoneId": "privatelink.azure-devices.net",
+          "azureIotPrivateDnsZoneId": "privatelink.azure-devices-provisioning.net",
+          "azureKeyVaultPrivateDnsZoneId": "privatelink.vaultcore.azure.net",
+          "azureKubernetesManagementPrivateDnsZoneId": "privatelink.{regionName}.azmk8s.io",
+          "azureMachineLearningWorkspacePrivateDnsZoneId": "privatelink.api.azureml.ms",
+          "azureMachineLearningWorkspaceSecondPrivateDnsZoneId": "privatelink.notebooks.azure.net",
+          "azureManagedGrafanaWorkspacePrivateDnsZoneId": "privatelink.grafana.azure.com",
+          "azureMediaServicesKeyPrivateDnsZoneId": "privatelink.media.azure.net",
+          "azureMediaServicesLivePrivateDnsZoneId": "privatelink.media.azure.net",
+          "azureMediaServicesStreamPrivateDnsZoneId": "privatelink.media.azure.net",
+          "azureMigratePrivateDnsZoneId": "privatelink.prod.migration.windowsazure.com",
+          "azureMonitorPrivateDnsZoneId1": "privatelink.monitor.azure.com",
+          "azureMonitorPrivateDnsZoneId2": "privatelink.oms.opinsights.azure.com",
+          "azureMonitorPrivateDnsZoneId3": "privatelink.ods.opinsights.azure.com",
+          "azureMonitorPrivateDnsZoneId4": "privatelink.agentsvc.azure-automation.net",
+          "azureMonitorPrivateDnsZoneId5": "privatelink.blob.core.windows.net",
+          "azureRedisCachePrivateDnsZoneId": "privatelink.redis.cache.windows.net",
+          "azureServiceBusNamespacePrivateDnsZoneId": "privatelink.servicebus.windows.net",
+          "azureSignalRPrivateDnsZoneId": "privatelink.service.signalr.net",
+          "azureSiteRecoveryBackupPrivateDnsZoneId": "privatelink.{regionCode}.backup.windowsazure.com",
+          "azureSiteRecoveryBlobPrivateDnsZoneId": "privatelink.blob.core.windows.net",
+          "azureSiteRecoveryQueuePrivateDnsZoneId": "privatelink.queue.core.windows.net",
+          "azureStorageBlobPrivateDnsZoneId": "privatelink.blob.core.windows.net",
+          "azureStorageBlobSecPrivateDnsZoneId": "privatelink.blob.core.windows.net",
+          "azureStorageDFSPrivateDnsZoneId": "privatelink.dfs.core.windows.net",
+          "azureStorageDFSSecPrivateDnsZoneId": "privatelink.dfs.core.windows.net",
+          "azureStorageFilePrivateDnsZoneId": "privatelink.file.core.windows.net",
+          "azureStorageQueuePrivateDnsZoneId": "privatelink.queue.core.windows.net",
+          "azureStorageQueueSecPrivateDnsZoneId": "privatelink.queue.core.windows.net",
+          "azureStorageStaticWebPrivateDnsZoneId": "privatelink.web.core.windows.net",
+          "azureStorageStaticWebSecPrivateDnsZoneId": "privatelink.web.core.windows.net",
+          "azureStorageTablePrivateDnsZoneId": "privatelink.table.core.windows.net",
+          "azureStorageTableSecondaryPrivateDnsZoneId": "privatelink.table.core.windows.net",
+          "azureSynapseDevPrivateDnsZoneId": "privatelink.dev.azuresynapse.net",
+          "azureSynapseSQLODPrivateDnsZoneId": "privatelink.sql.azuresynapse.net",
+          "azureSynapseSQLPrivateDnsZoneId": "privatelink.sql.azuresynapse.net",
+          "azureVirtualDesktopHostpoolPrivateDnsZoneId": "privatelink.wvd.microsoft.com",
+          "azureVirtualDesktopWorkspacePrivateDnsZoneId": "privatelink.wvd.microsoft.com",
+          "azureWebPrivateDnsZoneId": "privatelink.webpubsub.azure.com"
+        },
+        "metadata": {
+          "description": "The list of private DNS zone names to be used for the Azure PaaS services.",
+          "displayName": "DNS Zone Names"
+        },
+        "type": "object"
+      },
+      "dnsZoneRegion": {
+        "defaultValue": "changeme",
+        "metadata": {
+          "description": "The region where the private DNS zones are deployed. If this is specified, it will override any individual private DNS zone resource ids specified.",
+          "displayName": "Region"
+        },
+        "type": "string"
+      },
+      "dnsZoneResourceGroupName": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "The resource group where the private DNS zones are deployed. If this is specified, it will override any individual private DNS zone resource ids specified.",
+          "displayName": "Resource Group Name"
+        },
+        "type": "string"
+      },
+      "dnsZoneResourceType": {
+        "defaultValue": "Microsoft.Network/privateDnsZones",
+        "metadata": {
+          "description": "The resource type where the private DNS zones are deployed. If this is specified, it will override any individual private DNS zone resource ids specified.",
+          "displayName": "Resource Type"
+        },
+        "type": "string"
+      },
+      "dnsZoneSubscriptionId": {
+        "defaultValue": "",
+        "metadata": {
+          "description": "The subscription id where the private DNS zones are deployed. If this is specified, it will override any individual private DNS zone resource ids specified.",
+          "displayName": "Subscription Id"
+        },
+        "type": "string"
+      },
+      "dnzZoneRegionShortNames": {
+        "defaultValue": {
+          "australiacentral": "acl",
+          "australiacentral2": "acl2",
+          "australiaeast": "ae",
+          "australiasoutheast": "ase",
+          "brazilsouth": "brs",
+          "brazilsoutheast": "bse",
+          "canadacentral": "cnc",
+          "canadaeast": "cne",
+          "centralindia": "inc",
+          "centralus": "cus",
+          "centraluseuap": "ccy",
+          "changeme": "changeme",
+          "chilecentral": "clc",
+          "eastasia": "ea",
+          "eastus": "eus",
+          "eastus2": "eus2",
+          "eastus2euap": "ecy",
+          "francecentral": "frc",
+          "francesouth": "frs",
+          "germanynorth": "gn",
+          "germanywestcentral": "gwc",
+          "israelcentral": "ilc",
+          "italynorth": "itn",
+          "japaneast": "jpe",
+          "japanwest": "jpw",
+          "koreacentral": "krc",
+          "koreasouth": "krs",
+          "malaysiasouth": "mys",
+          "malaysiawest": "myw",
+          "mexicocentral": "mxc",
+          "newzealandnorth": "nzn",
+          "northcentralus": "ncus",
+          "northeurope": "ne",
+          "norwayeast": "nwe",
+          "norwaywest": "nww",
+          "polandcentral": "plc",
+          "qatarcentral": "qac",
+          "southafricanorth": "san",
+          "southafricawest": "saw",
+          "southcentralus": "scus",
+          "southeastasia": "sea",
+          "southindia": "ins",
+          "spaincentral": "spc",
+          "swedencentral": "sdc",
+          "swedensouth": "sds",
+          "switzerlandnorth": "szn",
+          "switzerlandwest": "szw",
+          "taiwannorth": "twn",
+          "uaecentral": "uac",
+          "uaenorth": "uan",
+          "uksouth": "uks",
+          "ukwest": "ukw",
+          "westcentralus": "wcus",
+          "westeurope": "we",
+          "westindia": "inw",
+          "westus": "wus",
+          "westus2": "wus2",
+          "westus3": "wus3"
+        },
+        "metadata": {
+          "description": "Mapping of region to private DNS zone resource id. If the region is not specified, the default private DNS zone resource id will be used.",
+          "displayName": "Region Short Name Mapping"
+        },
+        "type": "object"
+      },
+      "effect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Enable or disable the execution of the policy",
+          "displayName": "Effect"
+        },
+        "type": "string"
+      },
+      "effect1": {
+        "allowedValues": [
+          "deployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "deployIfNotExists",
+        "metadata": {
+          "description": "Enable or disable the execution of the policy",
+          "displayName": "Effect"
+        },
+        "type": "string"
+      }
+    },
+    "policyDefinitions": [
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureFilePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureFilePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/06695360-db88-47f6-b976-7500d4297475",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-File-Sync"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAutomationWebhookPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAutomationWebhookPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "Webhook"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6dd01e4f-1be1-4e80-9d0b-d109e04cb064",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Automation-Webhook"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAutomationDSCHybridPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAutomationDSCHybridPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "DSCAndHybridWorker"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6dd01e4f-1be1-4e80-9d0b-d109e04cb064",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Automation-DSCHybrid"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCosmosSQLPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCosmosSQLPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "SQL"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Cosmos-SQL"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCosmosMongoPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCosmosMongoPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "MongoDB"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Cosmos-MongoDB"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCosmosCassandraPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCosmosCassandraPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "Cassandra"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Cosmos-Cassandra"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCosmosGremlinPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCosmosGremlinPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "Gremlin"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Cosmos-Gremlin"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCosmosTablePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCosmosTablePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "Table"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Cosmos-Table"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "listOfGroupIds": {
+            "value": [
+              "dataFactory"
+            ]
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureDataFactoryPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureDataFactoryPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86cd96e1-1745-420d-94d4-d3f2fe415aa4",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-DataFactory"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "listOfGroupIds": {
+            "value": [
+              "portal"
+            ]
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureDataFactoryPortalPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureDataFactoryPortalPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86cd96e1-1745-420d-94d4-d3f2fe415aa4",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-DataFactory-Portal"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "databricks_ui_api"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureDatabricksPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureDatabricksPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0eddd7f3-3d9b-4927-a07a-806e8ac9486c",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Databricks-UI-Api"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "browser_authentication"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureDatabricksPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureDatabricksPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0eddd7f3-3d9b-4927-a07a-806e8ac9486c",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Databricks-Browser-AuthN"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "cluster"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureHDInsightPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureHDInsightPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/43d6e3bd-fc6a-4b44-8b4d-2151d8736a11",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-HDInsight"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMigratePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMigratePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7590a335-57cf-4c95-babd-ecbc8fafeb1f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Migrate"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageBlobPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageBlobPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/75973700-529f-4de2-b794-fb9b6781b6b0",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Blob"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageBlobSecPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageBlobSecPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d847d34b-9337-4e2d-99a5-767e5ac9c582",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Blob-Sec"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageQueuePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageQueuePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/bcff79fb-2b0d-47c9-97e5-3023479b00d1",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Queue"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageQueueSecPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageQueueSecPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/da9b4ae8-5ddc-48c5-b9c0-25f8abf7a3d6",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Queue-Sec"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageFilePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageFilePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6df98d03-368a-4438-8730-a93c4d7693d6",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-File"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageStaticWebPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageStaticWebPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9adab2a5-05ba-4fbd-831a-5bf958d04218",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-StaticWeb"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageStaticWebSecPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageStaticWebSecPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d19ae5f1-b303-4b82-9ca8-7682749faf0c",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-StaticWeb-Sec"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageDFSPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageDFSPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/83c6fe0f-2316-444a-99a1-1ecd8a7872ca",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-DFS"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageDFSSecPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageDFSSecPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/90bd4cb3-9f59-45f7-a6ca-f69db2726671",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-DFS-Sec"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSynapseSQLPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSynapseSQLPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "targetSubResource": {
+            "value": "Sql"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Synapse-SQL"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSynapseSQLODPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSynapseSQLODPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "targetSubResource": {
+            "value": "SqlOnDemand"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Synapse-SQL-OnDemand"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSynapseDevPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSynapseDevPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "targetSubResource": {
+            "value": "Dev"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Synapse-Dev"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "keydelivery"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMediaServicesKeyPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMediaServicesKeyPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-MediaServices-Key"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "liveevent"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMediaServicesLivePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMediaServicesLivePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-MediaServices-Live"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "groupId": {
+            "value": "streamingendpoint"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMediaServicesStreamPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMediaServicesStreamPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-MediaServices-Stream"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId1": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMonitorPrivateDnsZoneId1'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMonitorPrivateDnsZoneId1, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneId2": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMonitorPrivateDnsZoneId2'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMonitorPrivateDnsZoneId2, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneId3": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMonitorPrivateDnsZoneId3'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMonitorPrivateDnsZoneId3, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneId4": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMonitorPrivateDnsZoneId4'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMonitorPrivateDnsZoneId4, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneId5": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMonitorPrivateDnsZoneId5'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMonitorPrivateDnsZoneId5, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/437914ee-c176-4fff-8986-7e05eb971365",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Monitor"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureWebPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureWebPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0b026355-49cb-467b-8ac4-f777874e175a",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Web"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureBatchPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureBatchPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/4ec38ebc-381f-45ee-81a4-acbc4be878f8",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Batch"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAppPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAppPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7a860e27-9ca2-4fc6-822d-c2d248c300df",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-App"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAsrPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAsrPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/942bd215-1a66-44be-af65-6a1c0318dbe2",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Site-Recovery"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureIotPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureIotPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/aaa64d2d-2fa3-45e5-b332-0b031b9b30e8",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-IoT"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureKeyVaultPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureKeyVaultPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ac673a9a-f77d-4846-b2d8-a57f8e1c01d4",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-KeyVault"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSignalRPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSignalRPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0e86710-7fb7-4a6c-a064-32e9b829509e",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-SignalR"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAppServicesPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAppServicesPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b318f84a-b872-429b-ac6d-a01b96814452",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-AppServices"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect1')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureEventGridTopicsPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureEventGridTopicsPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/baf19753-7502-405f-8745-370519b20483",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-EventGridTopics"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureDiskAccessPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureDiskAccessPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/bc05b96c-0b36-4ca9-82f0-5c53f96ce05a",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-DiskAccess"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCognitiveServicesPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCognitiveServicesPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c4bc6f10-cb41-49eb-b000-d5ab82e2a091",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-CognitiveServices"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect1')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureIotHubsPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureIotHubsPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c99ce9c1-ced7-4c3e-aca0-10e69ce0cb02",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-IoTHubs"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect1')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureEventGridDomainsPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureEventGridDomainsPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d389df0a-e0d7-4607-833c-75a6fdac2c2d",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-EventGridDomains"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureRedisCachePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureRedisCachePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e016b22b-e0eb-436d-8fd7-160c4eaed6e2",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-RedisCache"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureAcrPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureAcrPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e9585a95-5b8c-4d03-b193-dc7eb5ac4c32",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-ACR"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureEventHubNamespacePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureEventHubNamespacePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ed66d4f5-8220-45dc-ab4a-20d1749c74e6",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-EventHubNamespace"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMachineLearningWorkspacePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMachineLearningWorkspacePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "secondPrivateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureMachineLearningWorkspaceSecondPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureMachineLearningWorkspaceSecondPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ee40564d-486e-4f68-a5ca-7a621edae0fb",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-MachineLearningWorkspace"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureServiceBusNamespacePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureServiceBusNamespacePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/f0fcf93c-c063-4071-9668-c47474bd3564",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-ServiceBusNamespace"
+      },
+      {
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureCognitiveSearchPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureCognitiveSearchPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fbc14a67-53e4-4932-abcc-2049c6706009",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-CognitiveSearch"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureBotServicePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureBotServicePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6a4e6f44-f2af-4082-9702-033c9e88b9f8",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-BotService"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureManagedGrafanaWorkspacePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureManagedGrafanaWorkspacePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/4c8537f8-cd1b-49ec-b704-18e82a42fd58",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-ManagedGrafanaWorkspace"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureVirtualDesktopHostpoolPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureVirtualDesktopHostpoolPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "connection"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9427df23-0f42-4e1e-bf99-a6133d841c4a",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-VirtualDesktopHostpool"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureVirtualDesktopWorkspacePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureVirtualDesktopWorkspacePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateEndpointGroupId": {
+            "value": "feed"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/34804460-d88b-4922-a7ca-537165e060ed",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-VirtualDesktopWorkspace"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureIotDeviceupdatePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureIotDeviceupdatePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a222b93a-e6c2-4c01-817f-21e092455b2a",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-IoTDeviceupdate"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneIDForGuestConfiguration": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureArcGuestconfigurationPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureArcGuestconfigurationPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneIDForHybridResourceProvider": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureArcHybridResourceProviderPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureArcHybridResourceProviderPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZoneIDForKubernetesConfiguration": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureArcKubernetesConfigurationPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureArcKubernetesConfigurationPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/55c4db33-97b0-437b-8469-c4f4498f5df9",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Arc"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureIotCentralPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureIotCentralPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d627d7c6-ded5-481a-8f2e-7e16b1e6faf6",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-IoTCentral"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageTablePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageTablePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/028bbd88-e9b5-461f-9424-a1b63a7bee1a",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Table"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZoneId": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureStorageTableSecondaryPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureStorageTableSecondaryPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c1d634a5-f73d-4cdd-889f-2cc7006eb47f",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Storage-Table-Secondary"
+      },
+      {
+        "parameters": {
+          "effect": {
+            "value": "[parameters('effect')]"
+          },
+          "privateDnsZone-Backup": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSiteRecoveryBackupPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSiteRecoveryBackupPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZone-Blob": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSiteRecoveryBlobPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSiteRecoveryBlobPrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          },
+          "privateDnsZone-Queue": {
+            "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureSiteRecoveryQueuePrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), replace(replace(parameters('dnsZoneNames').azureSiteRecoveryQueuePrivateDnsZoneId, '{regionName}', parameters('dnsZoneRegion')), '{regionCode}', parameters('dnzZoneRegionShortNames')[parameters('dnsZoneRegion')])))]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af783da1-4ad1-42be-800d-d19c70038820",
+        "policyDefinitionReferenceId": "DINE-Private-DNS-Azure-Site-Recovery-Backup"
+      }
+    ],
+    "policyType": "Custom"
+  },
+  "type": "Microsoft.Authorization/policySetDefinitions"
+}

--- a/integrationtest/testdata/policydefaultscomplexfunc/alz_policy_default_values.yaml
+++ b/integrationtest/testdata/policydefaultscomplexfunc/alz_policy_default_values.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - default_name: private_dns_zone_subscription_id
+    description: The subscription id that hosts the private link DNS zones.
+    policy_assignments:
+      - parameter_names:
+          - dnsZoneSubscriptionId
+        policy_assignment_name: Deploy-Private-DNS-Zones
+  - default_name: private_dns_zone_resource_group_name
+    description: The resource group name that hosts the private link DNS zones.
+    policy_assignments:
+      - parameter_names:
+          - dnsZoneResourceGroupName
+        policy_assignment_name: Deploy-Private-DNS-Zones
+  - default_name: private_dns_zone_region
+    description: The region short name (e.g. `westus`) that should be used for the region specific private link DNS zones.
+    policy_assignments:
+      - parameter_names:
+          - dnsZoneRegion
+        policy_assignment_name: Deploy-Private-DNS-Zones

--- a/integrationtest/testdata/policydefaultscomplexfunc/test.alz_archetype_definition.yml
+++ b/integrationtest/testdata/policydefaultscomplexfunc/test.alz_archetype_definition.yml
@@ -1,0 +1,5 @@
+name: test
+policy_assignments:
+  - Deploy-Private-DNS-Zones
+policy_set_definitions:
+  - Deploy-Private-DNS-Zones

--- a/integrationtest/testdata/policydefaultscomplexfunc/test.alz_architecture_definition.yaml
+++ b/integrationtest/testdata/policydefaultscomplexfunc/test.alz_architecture_definition.yaml
@@ -1,0 +1,8 @@
+management_groups:
+  - archetypes:
+      - test
+    display_name: test
+    exists: false
+    id: test
+    parent_id: null
+name: test


### PR DESCRIPTION
Allows alzlib to skip policy role assignments where it is unable to determine the correct role assignment scope. The emitted error can be used by callers to make a decision as to whether to halt execution or emit a warning with useful information.

In future we may include better ARM template function support, but until then this will allow upstream callers to handle this in a sensible way.

fixes Azure/Azure-Landing-Zones#1655

