### PR TITLE
fix: management group parent ID validation bug

### DIFF
--- a/alzlib_test.go
+++ b/alzlib_test.go
@@ -218,7 +218,7 @@ func TestGenerateArchitecturesTbt(t *testing.T) {
 					},
 				},
 			},
-			expectedError:  "",
+			expectedError:  "invalid parent",
 			expectedLength: 1,
 			expectedNotNil: "architecture1",
 		},

--- a/integrationtest/alzlib_test.go
+++ b/integrationtest/alzlib_test.go
@@ -105,3 +105,16 @@ func TestPolicyRoleAssignmentsWithComplexFunctions(t *testing.T) {
 	var roleAssignmentErrors *deployment.PolicyRoleAssignmentErrors
 	assert.NoError(t, err, roleAssignmentErrors)
 }
+
+func TestInvalidParent(t *testing.T) {
+	az := alzlib.NewAlzLib(nil)
+	lib := alzlib.NewCustomLibraryReference("./testdata/invalidparent")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	require.NoError(t, err)
+	cf, err := armpolicy.NewClientFactory("", cred, nil)
+	require.NoError(t, err)
+	az.AddPolicyClient(cf)
+	require.ErrorContains(t, az.Init(ctx, lib), "has invalid parent")
+}

--- a/integrationtest/testdata/invalidparent/invalidparent.alz_architecture_definition.yml
+++ b/integrationtest/testdata/invalidparent/invalidparent.alz_architecture_definition.yml
@@ -1,0 +1,14 @@
+name: invalid
+management_groups:
+  - archetypes:
+      - empty
+    display_name: parent
+    exists: false
+    id: parent
+    parent_id: null
+  - archetypes:
+      - empty
+    display_name: child
+    exists: false
+    id: child
+    parent_id: parent_invalid


### PR DESCRIPTION
Enhance validation to correctly identify invalid parent management group IDs. Add a test case to verify this behavior.