### PR TITLE
fix: error handling in alzlibtool and hierarchy checks

### DIFF
--- a/alzlib.go
+++ b/alzlib.go
@@ -823,6 +823,9 @@ func architectureRecursion(parents mapset.Set[string], libArch *processor.LibArc
 			if !parents.Contains(*mg.ParentId) {
 				continue
 			}
+			if !arch.mgs[*mg.ParentId].exists && mg.Exists {
+				return fmt.Errorf("architectureRecursion: error adding management group %s, which is configured as existing but the parent management group %s does not exist and would be created", mg.Id, *mg.ParentId)
+			}
 			if err := arch.addMgFromProcessor(mg, az); err != nil {
 				return fmt.Errorf("architectureRecursion: error adding management group %s: %w", mg.Id, err)
 			}

--- a/cmd/alzlibtool/command/check/library.go
+++ b/cmd/alzlibtool/command/check/library.go
@@ -25,20 +25,24 @@ var libraryCmd = cobra.Command{
 		creds, err := azidentity.NewDefaultAzureCredential(nil)
 		if err != nil {
 			cmd.PrintErrf("%s could not get Azure credential: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 		cf, err := armpolicy.NewClientFactory("", creds, nil)
 		if err != nil {
 			cmd.PrintErrf("%s could not create Azure policy client factory: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 		az.AddPolicyClient(cf)
 		thisRef := alzlib.NewCustomLibraryReference(args[0])
 		libs, err := thisRef.FetchWithDependencies(cmd.Context())
 		if err != nil {
 			cmd.PrintErrf("%s could not fetch all libraries with dependencies: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 		err = az.Init(cmd.Context(), libs...)
 		if err != nil {
 			cmd.PrintErrf("%s library init error: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 
 		chk := checker.NewValidator(

--- a/cmd/alzlibtool/command/document/library.go
+++ b/cmd/alzlibtool/command/document/library.go
@@ -18,10 +18,12 @@ var documentLibraryBaseCmd = cobra.Command{
 		alllibs, err := thislib.FetchWithDependencies(cmd.Context())
 		if err != nil {
 			cmd.PrintErrf("%s could not fetch all libraries with dependencies: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 		err = doc.AlzlibReadmeMd(cmd.Context(), os.Stdout, alllibs...)
 		if err != nil {
 			cmd.PrintErrf("%s library documentation error: %v\n", cmd.ErrPrefix(), err)
+			os.Exit(1)
 		}
 	},
 }

--- a/integrationtest/alzlib_test.go
+++ b/integrationtest/alzlib_test.go
@@ -118,3 +118,16 @@ func TestInvalidParent(t *testing.T) {
 	az.AddPolicyClient(cf)
 	require.ErrorContains(t, az.Init(ctx, lib), "has invalid parent")
 }
+
+func TestExistsChildOnNotExistParent(t *testing.T) {
+	az := alzlib.NewAlzLib(nil)
+	lib := alzlib.NewCustomLibraryReference("./testdata/existingchildwithnotexistingparent")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	require.NoError(t, err)
+	cf, err := armpolicy.NewClientFactory("", cred, nil)
+	require.NoError(t, err)
+	az.AddPolicyClient(cf)
+	require.ErrorContains(t, az.Init(ctx, lib), "which is configured as existing but the parent management group")
+}

--- a/integrationtest/testdata/existingchildwithnotexistingparent/test.alz_architecture_definition.yml
+++ b/integrationtest/testdata/existingchildwithnotexistingparent/test.alz_architecture_definition.yml
@@ -1,0 +1,14 @@
+name: notexistingparent
+management_groups:
+  - archetypes:
+      - empty
+    display_name: parent
+    exists: false
+    id: parent
+    parent_id: null
+  - archetypes:
+      - empty
+    display_name: child
+    exists: true
+    id: child
+    parent_id: parent


### PR DESCRIPTION
Implement error handling to ensure alzlibtool exits on critical errors and add checks to validate management group hierarchy integrity.