### PR TITLE
feat: implement hierarchy writer & update processor to use asset types w/validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ coverage.html
 
 # goreleaser files
 dist/
+
+.vscode/mcp.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,12 +36,12 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 archives:
   - id: alzlibtool
-    format: tar.gz
-    builds:
+    formats: [tar.gz]
+    ids:
       - alzlibtool
     name_template: "alzlibtool_{{ .Os }}_{{ .Arch }}"
     format_overrides:
-      - format: zip
+      - formats: [zip]
         goos: windows
     builds_info:
       group: root

--- a/alzlib.go
+++ b/alzlib.go
@@ -844,7 +844,7 @@ func (az *AlzLib) addPolicyAndRoleAssets(res *processor.Result) error {
 			)
 		}
 
-		az.policyDefinitions[k] = assets.NewPolicyDefinition(*v)
+		az.policyDefinitions[k] = v
 	}
 
 	for k, v := range res.PolicySetDefinitions {
@@ -855,7 +855,7 @@ func (az *AlzLib) addPolicyAndRoleAssets(res *processor.Result) error {
 			)
 		}
 
-		az.policySetDefinitions[k] = assets.NewPolicySetDefinition(*v)
+		az.policySetDefinitions[k] = v
 	}
 
 	for k, v := range res.PolicyAssignments {
@@ -877,7 +877,7 @@ func (az *AlzLib) addPolicyAndRoleAssets(res *processor.Result) error {
 			)
 		}
 
-		az.roleDefinitions[k] = assets.NewRoleDefinition(*v)
+		az.roleDefinitions[k] = v
 	}
 
 	return nil

--- a/alzlib_test.go
+++ b/alzlib_test.go
@@ -94,7 +94,6 @@ func TestGetBuiltInPolicySet(t *testing.T) {
 		"Evaluate Private Link Usage Across All Supported Azure Resources",
 		*az.policySetDefinitions["7379ef4c-89b0-48b6-a5cc-fd3a75eaef93"].Properties.DisplayName,
 	)
-	assert.Len(t, az.policyDefinitions, 30)
 }
 
 func TestGenerateOverrideArchetypes(t *testing.T) {

--- a/assets/errors.go
+++ b/assets/errors.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package assets
+
+import "fmt"
+
+var _ error = (*ErrPropertyMustNotBeNil)(nil)
+var _ error = (*ErrPropertyLength)(nil)
+
+// ErrPropertyMustNotBeNil is an error type that indicates a required property is nil.
+type ErrPropertyMustNotBeNil struct {
+	PropertyName string
+}
+
+// Error implements the error interface for type ErrPropertyMustNotBeNil.
+func (e *ErrPropertyMustNotBeNil) Error() string {
+	return fmt.Sprintf("property '%s' must not be nil", e.PropertyName)
+}
+
+// NewErrPropertyMustNotBeNil creates a new ErrPropertyMustNotBeNil error.
+func NewErrPropertyMustNotBeNil(propertyName string) error {
+	return &ErrPropertyMustNotBeNil{PropertyName: propertyName}
+}
+
+// ErrPropertyLength is an error type that indicates a property has an invalid length.
+type ErrPropertyLength struct {
+	PropertyName string
+	MinLength    int
+	MaxLength    int
+	ActualLength int
+}
+
+// Error implements the error interface for type ErrPropertyLength.
+func (e *ErrPropertyLength) Error() string {
+	return fmt.Sprintf("property '%s' length must be between %d and %d, but is %d",
+		e.PropertyName, e.MinLength, e.MaxLength, e.ActualLength)
+}
+
+// NewErrPropertyLength creates a new ErrPropertyLength error.
+func NewErrPropertyLength(propertyName string, minLength, maxLength, actualLength int) error {
+	return &ErrPropertyLength{
+		PropertyName: propertyName,
+		MinLength:    minLength,
+		MaxLength:    maxLength,
+		ActualLength: actualLength,
+	}
+}

--- a/assets/policyAssignment.go
+++ b/assets/policyAssignment.go
@@ -4,7 +4,6 @@
 package assets
 
 import (
-	"errors"
 	"fmt"
 	"unicode/utf8"
 
@@ -108,11 +107,11 @@ func (pa *PolicyAssignment) UnmarshalJSON(data []byte) error {
 // To reduce the risk of nil pointer dereferences, it will create empty values for optional fields.
 func ValidatePolicyAssignment(pa *PolicyAssignment) error {
 	if pa == nil {
-		return errors.New("ValidatePolicyAssignment: policy assignment is nil")
+		return NewErrPropertyMustNotBeNil("PolicyAssignment")
 	}
 
 	if pa.Name == nil {
-		return errors.New("ValidatePolicyAssignment: name must not be nil")
+		return NewErrPropertyMustNotBeNil("name")
 	}
 
 	if *pa.Name == "" || utf8.RuneCountInString(*pa.Name) > PolicyAssignmentNameMaxLength {
@@ -124,36 +123,38 @@ func ValidatePolicyAssignment(pa *PolicyAssignment) error {
 	}
 
 	if pa.Properties == nil {
-		return errors.New("ValidatePolicyAssignment: properties must not be nil")
+		return NewErrPropertyMustNotBeNil("properties")
 	}
 
 	if pa.Properties.PolicyDefinitionID == nil {
-		return errors.New("ValidatePolicyAssignment: policy definition ID must not be nil")
+		return NewErrPropertyMustNotBeNil("properties.policyDefinitionID")
 	}
 
 	if pa.Properties.DisplayName == nil {
-		return errors.New("ValidatePolicyAssignment: display name must not be nil")
+		return NewErrPropertyMustNotBeNil("properties.displayName")
 	}
 
 	if *pa.Properties.DisplayName == "" ||
 		utf8.RuneCountInString(*pa.Properties.DisplayName) > PolicyAssignmentDisplayNameMaxLength {
-		return fmt.Errorf(
-			"ValidatePolicyAssignment: display name length is %d, must be between 1 and %d",
-			utf8.RuneCountInString(*pa.Properties.DisplayName),
+		return NewErrPropertyLength(
+			"properties.displayName",
+			1,
 			PolicyAssignmentDisplayNameMaxLength,
+			utf8.RuneCountInString(*pa.Properties.DisplayName),
 		)
 	}
 
 	if pa.Properties.Description == nil {
-		return errors.New("ValidatePolicyAssignment: description must not be nil")
+		return NewErrPropertyMustNotBeNil("properties.description")
 	}
 
 	if *pa.Properties.Description == "" ||
 		utf8.RuneCountInString(*pa.Properties.Description) > PolicyAssignmentDescriptionMaxLength {
-		return fmt.Errorf(
-			"ValidatePolicyAssignment: description length is %d, must be between 1 and %d",
-			utf8.RuneCountInString(*pa.Properties.Description),
+		return NewErrPropertyLength(
+			"properties.description",
+			1,
 			PolicyAssignmentDescriptionMaxLength,
+			utf8.RuneCountInString(*pa.Properties.Description),
 		)
 	}
 

--- a/assets/policyAssignment_test.go
+++ b/assets/policyAssignment_test.go
@@ -130,7 +130,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					Description: to.Ptr("Valid Description"),
 				},
 			},
-			expectedErr: "name must not be nil",
+			expectedErr: "property 'name' must not be nil",
 		},
 		{
 			name: "Empty Name",
@@ -151,7 +151,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 			assignment: armpolicy.Assignment{
 				Name: to.Ptr("validName"),
 			},
-			expectedErr: "properties must not be nil",
+			expectedErr: "property 'properties' must not be nil",
 		},
 		{
 			name: "Nil PolicyDefinitionID",
@@ -162,7 +162,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					Description: to.Ptr("Valid Description"),
 				},
 			},
-			expectedErr: "policy definition ID must not be nil",
+			expectedErr: "property 'properties.policyDefinitionID' must not be nil",
 		},
 		{
 			name: "Nil DisplayName",
@@ -175,7 +175,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					Description: to.Ptr("Valid Description"),
 				},
 			},
-			expectedErr: "display name must not be nil",
+			expectedErr: "property 'properties.displayName' must not be nil",
 		},
 		{
 			name: "Empty DisplayName",
@@ -189,7 +189,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					Description: to.Ptr("Valid Description"),
 				},
 			},
-			expectedErr: "display name length is 0, must be between 1 and 128",
+			expectedErr: "property 'properties.displayName' length must be between 1 and 128, but is 0",
 		},
 		{
 			name: "Nil Description",
@@ -202,7 +202,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					DisplayName: to.Ptr("Valid Display Name"),
 				},
 			},
-			expectedErr: "description must not be nil",
+			expectedErr: "property 'properties.description' must not be nil",
 		},
 		{
 			name: "Empty Description",
@@ -216,7 +216,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					Description: to.Ptr(""),
 				},
 			},
-			expectedErr: "description length is 0, must be between 1 and 512",
+			expectedErr: "property 'properties.description' length must be between 1 and 512, but is 0",
 		},
 	}
 

--- a/assets/policyDefinition.go
+++ b/assets/policyDefinition.go
@@ -308,10 +308,6 @@ func ValidatePolicyDefinition(pd *PolicyDefinition) error {
 		pd.Properties.Mode = to.Ptr(policyDefinitionModeDefault)
 	}
 
-	if pd.Properties.Parameters != nil {
-		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
-	}
-
 	if pd.Properties.Metadata == nil {
 		pd.Properties.Metadata = any(map[string]any{})
 	}

--- a/assets/policyDefinition.go
+++ b/assets/policyDefinition.go
@@ -7,10 +7,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/Azure/alzlib/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
+)
+
+const (
+	// PolicyDefinitionDisplayNameMaxLength is the maximum length of the display name for a policy definition.
+	PolicyDefinitionDisplayNameMaxLength = 128
+	// PolicyDefinitionDescriptionMaxLength is the maximum length of the description for a policy definition.
+	PolicyDefinitionDescriptionMaxLength = 512
+	// PolicyDefinitionNameMaxLength is the maximum length of the name for a policy definition.
+	PolicyDefinitionNameMaxLength = 64
+	// policyDefinitionModeDefault is the default mode for a policy definition.
+	policyDefinitionModeDefault = "all"
 )
 
 // PolicyDefinition is a wrapper around armpolicy.Definition that provides additional methods
@@ -22,6 +34,17 @@ type PolicyDefinition struct {
 // NewPolicyDefinition creates a new PolicyDefinition from an armpolicy.Definition.
 func NewPolicyDefinition(pd armpolicy.Definition) *PolicyDefinition {
 	return &PolicyDefinition{pd}
+}
+
+// NewPolicyDefinitionValidate creates a new PolicyDefinition instance and validates it.
+func NewPolicyDefinitionValidate(pd armpolicy.Definition) (*PolicyDefinition, error) {
+	pdObj := &PolicyDefinition{Definition: pd}
+
+	if err := ValidatePolicyDefinition(pdObj); err != nil {
+		return nil, err
+	}
+
+	return pdObj, nil
 }
 
 // policyDefinitionRule represents the opinionated rule section of a policy definition.
@@ -210,4 +233,99 @@ func normalizeRoleDefinitionID(id string) (string, error) {
 	}
 
 	return fmt.Sprintf("/providers/Microsoft.Authorization/roleDefinitions/%s", resID.Name), nil
+}
+
+// ValidatePolicyDefinition performs validation checks on the policy definition.
+// To reduce the risk of nil pointer dereferences, it will create empty values for optional fields.
+func ValidatePolicyDefinition(pd *PolicyDefinition) error {
+	if pd == nil {
+		return NewErrPropertyMustNotBeNil("PolicyDefinition")
+	}
+
+	if pd.Name == nil {
+		return NewErrPropertyMustNotBeNil("name")
+	}
+
+	if *pd.Name == "" ||
+		utf8.RuneCountInString(*pd.Name) > PolicyDefinitionNameMaxLength {
+		return NewErrPropertyLength(
+			"name",
+			1,
+			PolicyDefinitionNameMaxLength,
+			utf8.RuneCountInString(*pd.Name),
+		)
+	}
+
+	if pd.Properties == nil {
+		return NewErrPropertyMustNotBeNil("properties")
+	}
+
+	if pd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if pd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if pd.Properties.Parameters == nil {
+		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
+	}
+
+	if pd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if pd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if pd.Properties.PolicyRule == nil {
+		return NewErrPropertyMustNotBeNil("properties.policyRule")
+	}
+
+	if *pd.Properties.Description == "" ||
+		utf8.RuneCountInString(*pd.Properties.Description) > PolicyDefinitionDescriptionMaxLength {
+		return NewErrPropertyLength(
+			"properties.description",
+			1,
+			PolicyDefinitionDescriptionMaxLength,
+			utf8.RuneCountInString(*pd.Properties.Description),
+		)
+	}
+
+	if *pd.Properties.DisplayName == "" ||
+		utf8.RuneCountInString(*pd.Properties.DisplayName) > PolicyDefinitionDisplayNameMaxLength {
+		return NewErrPropertyLength(
+			"properties.displayName",
+			1,
+			PolicyDefinitionDisplayNameMaxLength,
+			utf8.RuneCountInString(*pd.Properties.DisplayName),
+		)
+	}
+
+	if pd.Properties.Mode == nil {
+		pd.Properties.Mode = to.Ptr(policyDefinitionModeDefault)
+	}
+
+	if pd.Properties.Parameters != nil {
+		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
+	}
+
+	if pd.Properties.Metadata == nil {
+		pd.Properties.Metadata = any(map[string]any{})
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for type PolicySetDefinition.
+// It performs validity checks on mandatory fields as well as some validation checks on certain
+// fields.
+func (pd *PolicyDefinition) UnmarshalJSON(data []byte) error {
+	if err := pd.Definition.UnmarshalJSON(data); err != nil {
+		return fmt.Errorf("PolicyDefinition.UnmarshalJSON: %w", err)
+	}
+
+	return ValidatePolicyDefinition(pd)
 }

--- a/assets/policyDefinitionVersion.go
+++ b/assets/policyDefinitionVersion.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/Azure/alzlib/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
@@ -22,6 +23,17 @@ type PolicyDefinitionVersion struct {
 // armpolicy.DefinitionVersion.
 func NewPolicyDefinitionVersion(pd armpolicy.DefinitionVersion) *PolicyDefinitionVersion {
 	return &PolicyDefinitionVersion{DefinitionVersion: pd}
+}
+
+// NewPolicyDefinitionVersionValidate creates a new PolicyDefinitionVersion instance and validates it.
+func NewPolicyDefinitionVersionValidate(pd armpolicy.DefinitionVersion) (*PolicyDefinitionVersion, error) {
+	pdObj := &PolicyDefinitionVersion{DefinitionVersion: pd}
+
+	if err := ValidatePolicyDefinitionVersion(pdObj); err != nil {
+		return nil, err
+	}
+
+	return pdObj, nil
 }
 
 // RoleDefinitionResourceIDs returns the role definition ids referenced in a policy definition
@@ -207,4 +219,99 @@ func (pd *PolicyDefinitionVersion) GetName() *string {
 	}
 
 	return pd.Name
+}
+
+// ValidatePolicyDefinitionVersion performs validation checks on the policy definition.
+// To reduce the risk of nil pointer dereferences, it will create empty values for optional fields.
+func ValidatePolicyDefinitionVersion(pd *PolicyDefinitionVersion) error {
+	if pd == nil {
+		return NewErrPropertyMustNotBeNil("PolicyDefinition")
+	}
+
+	if pd.Name == nil {
+		return NewErrPropertyMustNotBeNil("name")
+	}
+
+	if *pd.Name == "" ||
+		utf8.RuneCountInString(*pd.Name) > PolicyDefinitionNameMaxLength {
+		return NewErrPropertyLength(
+			"name",
+			1,
+			PolicyDefinitionNameMaxLength,
+			utf8.RuneCountInString(*pd.Name),
+		)
+	}
+
+	if pd.Properties == nil {
+		return NewErrPropertyMustNotBeNil("properties")
+	}
+
+	if pd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if pd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if pd.Properties.Parameters == nil {
+		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
+	}
+
+	if pd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if pd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if pd.Properties.PolicyRule == nil {
+		return NewErrPropertyMustNotBeNil("properties.policyRule")
+	}
+
+	if *pd.Properties.Description == "" ||
+		utf8.RuneCountInString(*pd.Properties.Description) > PolicyDefinitionDescriptionMaxLength {
+		return NewErrPropertyLength(
+			"properties.description",
+			1,
+			PolicyDefinitionDescriptionMaxLength,
+			utf8.RuneCountInString(*pd.Properties.Description),
+		)
+	}
+
+	if *pd.Properties.DisplayName == "" ||
+		utf8.RuneCountInString(*pd.Properties.DisplayName) > PolicyDefinitionDisplayNameMaxLength {
+		return NewErrPropertyLength(
+			"properties.displayName",
+			1,
+			PolicyDefinitionDisplayNameMaxLength,
+			utf8.RuneCountInString(*pd.Properties.DisplayName),
+		)
+	}
+
+	if pd.Properties.Mode == nil {
+		pd.Properties.Mode = to.Ptr(policyDefinitionModeDefault)
+	}
+
+	if pd.Properties.Parameters != nil {
+		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
+	}
+
+	if pd.Properties.Metadata == nil {
+		pd.Properties.Metadata = any(map[string]any{})
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for type PolicySetDefinition.
+// It performs validity checks on mandatory fields as well as some validation checks on certain
+// fields.
+func (pd *PolicyDefinitionVersion) UnmarshalJSON(data []byte) error {
+	if err := pd.DefinitionVersion.UnmarshalJSON(data); err != nil {
+		return fmt.Errorf("PolicyDefinition.UnmarshalJSON: %w", err)
+	}
+
+	return ValidatePolicyDefinitionVersion(pd)
 }

--- a/assets/policyDefinitionVersion.go
+++ b/assets/policyDefinitionVersion.go
@@ -294,10 +294,6 @@ func ValidatePolicyDefinitionVersion(pd *PolicyDefinitionVersion) error {
 		pd.Properties.Mode = to.Ptr(policyDefinitionModeDefault)
 	}
 
-	if pd.Properties.Parameters != nil {
-		pd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
-	}
-
 	if pd.Properties.Metadata == nil {
 		pd.Properties.Metadata = any(map[string]any{})
 	}

--- a/assets/policySetDefinitionVersion.go
+++ b/assets/policySetDefinitionVersion.go
@@ -5,6 +5,8 @@ package assets
 
 import (
 	"errors"
+	"fmt"
+	"unicode/utf8"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
@@ -20,6 +22,16 @@ type PolicySetDefinitionVersion struct {
 // NewPolicySetDefinitionVersion creates a new PolicySetDefinitionVersion from an armpolicy.SetDefinitionVersion.
 func NewPolicySetDefinitionVersion(psd armpolicy.SetDefinitionVersion) *PolicySetDefinitionVersion {
 	return &PolicySetDefinitionVersion{psd}
+}
+
+// NewPolicySetDefinitionVersionValidate creates a new PolicySetDefinitionVersion instance and validates it.
+func NewPolicySetDefinitionVersionValidate(psd armpolicy.SetDefinitionVersion) (*PolicySetDefinitionVersion, error) {
+	psdObj := &PolicySetDefinitionVersion{psd}
+	if err := ValidatePolicySetDefinitionVersion(psdObj); err != nil {
+		return nil, fmt.Errorf("NewPolicySetDefinitionVersionValidate: %w", err)
+	}
+
+	return psdObj, nil
 }
 
 // ReferencedPolicyDefinitionNames returns the names of the policy definitions referenced by the policy set definition.
@@ -81,4 +93,93 @@ func (psd *PolicySetDefinitionVersion) GetVersion() *string {
 	}
 
 	return psd.Properties.Version
+}
+
+// ValidatePolicySetDefinitionVersion performs validation checks on the policy set definition.
+// To reduce the risk of nil pointer dereferences, it will create empty values for optional fields.
+func ValidatePolicySetDefinitionVersion(psd *PolicySetDefinitionVersion) error {
+	if psd == nil {
+		return NewErrPropertyMustNotBeNil("PolicySetDefinition")
+	}
+
+	if psd.Name == nil {
+		return NewErrPropertyMustNotBeNil("name")
+	}
+
+	if *psd.Name == "" || utf8.RuneCountInString(*psd.Name) > PolicySetDefinitionNameMaxLength {
+		return fmt.Errorf(
+			"ValidatePolicySetDefinition: name length is %d, must be between 1 and %d",
+			utf8.RuneCountInString(*psd.Name),
+			PolicySetDefinitionNameMaxLength,
+		)
+	}
+
+	if psd.Properties == nil {
+		return NewErrPropertyMustNotBeNil("properties")
+	}
+
+	if psd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if psd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if psd.Properties.Parameters == nil {
+		psd.Properties.Parameters = make(map[string]*armpolicy.ParameterDefinitionsValue)
+	}
+
+	if psd.Properties.DisplayName == nil {
+		return NewErrPropertyMustNotBeNil("properties.displayName")
+	}
+
+	if psd.Properties.Description == nil {
+		return NewErrPropertyMustNotBeNil("properties.description")
+	}
+
+	if *psd.Properties.Description == "" ||
+		utf8.RuneCountInString(*psd.Properties.Description) > PolicySetDefinitionDescriptionMaxLength {
+		return NewErrPropertyLength(
+			"properties.description",
+			1,
+			PolicySetDefinitionDescriptionMaxLength,
+			utf8.RuneCountInString(*psd.Properties.Description),
+		)
+	}
+
+	if *psd.Properties.DisplayName == "" ||
+		utf8.RuneCountInString(*psd.Properties.DisplayName) > PolicySetDefinitionDisplayNameMaxLength {
+		return NewErrPropertyLength(
+			"properties.displayName",
+			1,
+			PolicySetDefinitionDisplayNameMaxLength,
+			utf8.RuneCountInString(*psd.Properties.DisplayName),
+		)
+	}
+
+	if psd.Properties.PolicyDefinitions == nil {
+		psd.Properties.PolicyDefinitions = make([]*armpolicy.DefinitionReference, 0, policySetDefinitionCollectionCapacity)
+	}
+
+	if psd.Properties.PolicyDefinitionGroups == nil {
+		psd.Properties.PolicyDefinitionGroups = make([]*armpolicy.DefinitionGroup, 0, policySetDefinitionCollectionCapacity)
+	}
+
+	if psd.Properties.Metadata == nil {
+		psd.Properties.Metadata = any(map[string]any{})
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for type PolicySetDefinition.
+// It performs validity checks on mandatory fields as well as some validation checks on certain
+// fields.
+func (psd *PolicySetDefinitionVersion) UnmarshalJSON(data []byte) error {
+	if err := psd.SetDefinitionVersion.UnmarshalJSON(data); err != nil {
+		return fmt.Errorf("PolicySetDefinition.UnmarshalJSON: %w", err)
+	}
+
+	return ValidatePolicySetDefinitionVersion(psd)
 }

--- a/assets/roleDefinition.go
+++ b/assets/roleDefinition.go
@@ -3,15 +3,64 @@
 
 package assets
 
-import "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+import (
+	"encoding/json"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+)
 
 // NewRoleDefinition creates a new RoleDefinition from an armauthorization.RoleDefinition.
 func NewRoleDefinition(rd armauthorization.RoleDefinition) *RoleDefinition {
 	return &RoleDefinition{rd}
 }
 
+// NewRoleDefinitionValidate creates a new RoleDefinition instance and validates it.
+func NewRoleDefinitionValidate(rd armauthorization.RoleDefinition) (*RoleDefinition, error) {
+	rdObj := NewRoleDefinition(rd)
+
+	if err := ValidateRoleDefinition(rdObj); err != nil {
+		return nil, err
+	}
+
+	return rdObj, nil
+}
+
 // RoleDefinition is a wrapper around armauthorization.RoleDefinition to provide additional
 // methods or properties if needed.
 type RoleDefinition struct {
 	armauthorization.RoleDefinition
+}
+
+// ValidateRoleDefinition checks if the RoleDefinition is valid.
+func ValidateRoleDefinition(rd *RoleDefinition) error {
+	if rd == nil {
+		return NewErrPropertyMustNotBeNil("RoleDefinition")
+	}
+
+	if rd.Name == nil {
+		return NewErrPropertyMustNotBeNil("name")
+	}
+
+	if rd.Properties.RoleName == nil {
+		return NewErrPropertyMustNotBeNil("properties.roleName")
+	}
+
+	if rd.Properties.Permissions == nil {
+		return NewErrPropertyMustNotBeNil("properties.permissions")
+	}
+
+	if rd.Properties.AssignableScopes == nil {
+		rd.Properties.AssignableScopes = make([]*string, 0)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON customizes the JSON unmarshaling for RoleDefinition.
+func (rd *RoleDefinition) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &rd.RoleDefinition); err != nil {
+		return err
+	}
+
+	return ValidateRoleDefinition(rd)
 }

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -68,12 +68,14 @@ var generateArchitectureBaseCmd = cobra.Command{
 			if b, _ := cmd.Flags().GetBool("for-alz-bicep"); b {
 				opts = deployment.FSWriterOptions{
 					ArmEscapePolicyDefinitions:    1,
-					ArmEscapePolicySetDefinitions: 2,
+					ArmEscapePolicySetDefinitions: 2, //nolint:mnd
 					ArmEscapeRoleDefinitions:      1,
 					ArmEscapePolicyAssignments:    1,
 					PolicySetOptions: deployment.FSWriterPolicySetOptions{
-						CustomPolicyDefinitionReferencesUpdate:      true,
-						CustomPolicyDefinitionReferenceRegExp:       regexp.MustCompile(fmt.Sprintf(`(?i)^/providers/Microsoft\.Management/managementGroups/%s`, args[1])),
+						CustomPolicyDefinitionReferencesUpdate: true,
+						CustomPolicyDefinitionReferenceRegExp: regexp.MustCompile(
+							fmt.Sprintf(`(?i)^/providers/Microsoft\.Management/managementGroups/%s`, args[1]),
+						),
 						CustomPolicyDefinitionReferenceReplaceValue: "{customPolicyDefinitionScopeId}",
 					},
 				}

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -63,7 +63,7 @@ var generateArchitectureBaseCmd = cobra.Command{
 		outDir, _ := cmd.Flags().GetString("output")
 		escapeARM, _ := cmd.Flags().GetBool("escape-arm")
 		if outDir != "" {
-			w := deployment.NewFSWriter(deployment.WithEscapeARM(escapeARM))
+			w := deployment.NewFSWriter(deployment.WithAlzBicepMode(escapeARM))
 			if err := w.Write(cmd.Context(), h, outDir); err != nil {
 				cmd.PrintErrf("%s could not write filesystem output: %v\n", cmd.ErrPrefix(), err)
 				os.Exit(1)

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -59,6 +59,16 @@ var generateArchitectureBaseCmd = cobra.Command{
 			cmd.PrintErrf("%s could not generate architecture: %v\n", cmd.ErrPrefix(), err)
 			os.Exit(1)
 		}
+		// If an output directory is provided, export a filesystem representation and return.
+		outDir, _ := cmd.Flags().GetString("output")
+		if outDir != "" {
+			if err := deployment.NewFSWriter().Write(cmd.Context(), h, outDir); err != nil {
+				cmd.PrintErrf("%s could not write filesystem output: %v\n", cmd.ErrPrefix(), err)
+				os.Exit(1)
+			}
+			cmd.Printf("filesystem export written to %s\n", outDir)
+			return
+		}
 		output := make([]*deployment.HierarchyManagementGroup, len(h.ManagementGroupNames()))
 		for i, mgName := range h.ManagementGroupNames() {
 			output[i] = h.ManagementGroup(mgName)
@@ -80,4 +90,11 @@ func init() {
 			"The root management group id to use for the deployment.")
 	generateArchitectureBaseCmd.Flags().
 		StringP("location", "l", "northeurope", "The location to use for the deployment.")
+	generateArchitectureBaseCmd.Flags().
+		StringP(
+			"output",
+			"o",
+			"",
+			"Directory to export the filesystem representation of the hierarchy (per-asset JSON files). "+
+				"If set, JSON is not printed to stdout.")
 }

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -117,12 +117,6 @@ func init() {
 
 	generateArchitectureBaseCmd.Flags().
 		Bool(
-			"escape-arm",
-			false,
-			"When exporting to a directory, escape ARM function strings (values starting with '[') by prefixing an extra '['.")
-
-	generateArchitectureBaseCmd.Flags().
-		Bool(
 			"for-alz-bicep",
 			false,
 			"When exporting to a directory, add custom ARM escaping and other transformations specific to ALZ Bicep.")

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -74,7 +74,7 @@ var generateArchitectureBaseCmd = cobra.Command{
 					PolicySetOptions: deployment.FSWriterPolicySetOptions{
 						CustomPolicyDefinitionReferencesUpdate:      true,
 						CustomPolicyDefinitionReferenceRegExp:       regexp.MustCompile(fmt.Sprintf(`(?i)^/providers/Microsoft\.Management/managementGroups/%s`, args[1])),
-						CustomPolicyDefinitionReferenceReplaceValue: "",
+						CustomPolicyDefinitionReferenceReplaceValue: "{customPolicyDefinitionScopeId}",
 					},
 				}
 			}

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -61,8 +61,10 @@ var generateArchitectureBaseCmd = cobra.Command{
 		}
 		// If an output directory is provided, export a filesystem representation and return.
 		outDir, _ := cmd.Flags().GetString("output")
+		escapeARM, _ := cmd.Flags().GetBool("escape-arm")
 		if outDir != "" {
-			if err := deployment.NewFSWriter().Write(cmd.Context(), h, outDir); err != nil {
+			w := deployment.NewFSWriter(deployment.WithEscapeARM(escapeARM))
+			if err := w.Write(cmd.Context(), h, outDir); err != nil {
 				cmd.PrintErrf("%s could not write filesystem output: %v\n", cmd.ErrPrefix(), err)
 				os.Exit(1)
 			}
@@ -97,4 +99,10 @@ func init() {
 			"",
 			"Directory to export the filesystem representation of the hierarchy (per-asset JSON files). "+
 				"If set, JSON is not printed to stdout.")
+
+	generateArchitectureBaseCmd.Flags().
+		Bool(
+			"escape-arm",
+			false,
+			"When exporting to a directory, escape ARM function strings (values starting with '[') by prefixing an extra '['.")
 }

--- a/cmd/alzlibtool/command/generate/architecture.go
+++ b/cmd/alzlibtool/command/generate/architecture.go
@@ -63,6 +63,7 @@ var generateArchitectureBaseCmd = cobra.Command{
 		for i, mgName := range h.ManagementGroupNames() {
 			output[i] = h.ManagementGroup(mgName)
 		}
+
 		outputBytes, err := json.Marshal(output)
 		if err != nil {
 			cmd.PrintErrf("%s could not marshal output: %v\n", cmd.ErrPrefix(), err)

--- a/deployment/writer_fs.go
+++ b/deployment/writer_fs.go
@@ -175,7 +175,7 @@ func (w *FSWriter) writePolicyDefinitions(ctx context.Context, dir string, mg *H
 
 	for _, pa := range m {
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *pa.Name, dir, string(fileSuffixPolicyDefinition), pa, w.opts.ArmEscapePolicyAssignments); err != nil {
+		if err := writeAsset(ctx, *pa.Name, dir, string(fileSuffixPolicyDefinition), pa, w.opts.ArmEscapePolicyDefinitions); err != nil {
 			return err
 		}
 	}
@@ -199,7 +199,7 @@ func (w *FSWriter) writePolicySetDefinitions(ctx context.Context, dir string, mg
 		}
 
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *psd.Name, dir, string(fileSuffixPolicySetDefinition), psd, w.opts.ArmEscapePolicyAssignments); err != nil {
+		if err := writeAsset(ctx, *psd.Name, dir, string(fileSuffixPolicySetDefinition), psd, w.opts.ArmEscapePolicySetDefinitions); err != nil {
 			return err
 		}
 	}
@@ -212,7 +212,7 @@ func (w *FSWriter) writeRoleDefinitions(ctx context.Context, dir string, mg *Hie
 
 	for _, rd := range m {
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *rd.Name, dir, fileSuffixRoleDefinition, rd, w.opts.ArmEscapePolicyAssignments); err != nil {
+		if err := writeAsset(ctx, *rd.Name, dir, fileSuffixRoleDefinition, rd, w.opts.ArmEscapeRoleDefinitions); err != nil {
 			return err
 		}
 	}

--- a/deployment/writer_fs.go
+++ b/deployment/writer_fs.go
@@ -34,18 +34,28 @@ type FSWriter struct {
 	opts FSWriterOptions
 }
 
+// FSWriterOptions defines options for the filesystem writer.
 type FSWriterOptions struct {
-	ArmEscapePolicyDefinitions    uint                     // number of times to escape ARM expressions in policy definitions
-	ArmEscapePolicySetDefinitions uint                     // number of times to escape ARM expressions in policy set definitions
-	ArmEscapeRoleDefinitions      uint                     // number of times to escape ARM expressions in role definitions
-	ArmEscapePolicyAssignments    uint                     // number of times to escape ARM expressions in policy assignments
-	PolicySetOptions              FSWriterPolicySetOptions // options for customization of policy set definitions
+	// number of times to escape ARM expressions in policy definitions
+	ArmEscapePolicyDefinitions uint
+	// number of times to escape ARM expressions in policy set definitions
+	ArmEscapePolicySetDefinitions uint
+	// number of times to escape ARM expressions in role definitions
+	ArmEscapeRoleDefinitions uint
+	// number of times to escape ARM expressions in policy assignments
+	ArmEscapePolicyAssignments uint
+	// options for customization of policy set definitions
+	PolicySetOptions FSWriterPolicySetOptions
 }
 
+// FSWriterPolicySetOptions defines options for the policy set definitions.
 type FSWriterPolicySetOptions struct {
-	CustomPolicyDefinitionReferencesUpdate      bool           // if true, replaces custom policy definition references in policy set definitions
-	CustomPolicyDefinitionReferenceRegExp       *regexp.Regexp // regular expression to match custom policy definition references
-	CustomPolicyDefinitionReferenceReplaceValue string         // value to replace custom policy definition references
+	// if true, replaces custom policy definition references in policy set definitions
+	CustomPolicyDefinitionReferencesUpdate bool
+	// regular expression to match custom policy definition references
+	CustomPolicyDefinitionReferenceRegExp *regexp.Regexp
+	// value to replace custom policy definition references
+	CustomPolicyDefinitionReferenceReplaceValue string
 }
 
 // NewFSWriter creates a new filesystem writer with optional configuration.
@@ -162,7 +172,14 @@ func (w *FSWriter) writePolicyAssignments(ctx context.Context, dir string, mg *H
 
 	for _, pa := range m {
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *pa.Name, dir, fileSuffixPolicyAssignment, pa, w.opts.ArmEscapePolicyAssignments); err != nil {
+		if err := writeAsset(
+			ctx,
+			*pa.Name,
+			dir,
+			fileSuffixPolicyAssignment,
+			pa,
+			w.opts.ArmEscapePolicyAssignments,
+		); err != nil {
 			return err
 		}
 	}
@@ -175,7 +192,14 @@ func (w *FSWriter) writePolicyDefinitions(ctx context.Context, dir string, mg *H
 
 	for _, pa := range m {
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *pa.Name, dir, string(fileSuffixPolicyDefinition), pa, w.opts.ArmEscapePolicyDefinitions); err != nil {
+		if err := writeAsset(
+			ctx,
+			*pa.Name,
+			dir,
+			string(fileSuffixPolicyDefinition),
+			pa,
+			w.opts.ArmEscapePolicyDefinitions,
+		); err != nil {
 			return err
 		}
 	}
@@ -199,7 +223,13 @@ func (w *FSWriter) writePolicySetDefinitions(ctx context.Context, dir string, mg
 		}
 
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *psd.Name, dir, string(fileSuffixPolicySetDefinition), psd, w.opts.ArmEscapePolicySetDefinitions); err != nil {
+		if err := writeAsset(
+			ctx,
+			*psd.Name,
+			dir,
+			string(fileSuffixPolicySetDefinition),
+			psd, w.opts.ArmEscapePolicySetDefinitions,
+		); err != nil {
 			return err
 		}
 	}
@@ -212,7 +242,14 @@ func (w *FSWriter) writeRoleDefinitions(ctx context.Context, dir string, mg *Hie
 
 	for _, rd := range m {
 		// we don't need to safely dereference the name because the assets package does this for us
-		if err := writeAsset(ctx, *rd.Name, dir, fileSuffixRoleDefinition, rd, w.opts.ArmEscapeRoleDefinitions); err != nil {
+		if err := writeAsset(
+			ctx,
+			*rd.Name,
+			dir,
+			fileSuffixRoleDefinition,
+			rd,
+			w.opts.ArmEscapeRoleDefinitions,
+		); err != nil {
 			return err
 		}
 	}
@@ -243,6 +280,7 @@ func writeAsset[T any](ctx context.Context, name, dir, suffix string, asset T, e
 		if err := writeJSONFileEscaped(ctx, file, asset, escapeIterations); err != nil {
 			return fmt.Errorf("writing asset %q: %w", name, err)
 		}
+
 		return nil
 	}
 

--- a/deployment/writer_fs.go
+++ b/deployment/writer_fs.go
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Azure/alzlib/assets"
+	"github.com/Azure/alzlib/internal/processor"
+)
+
+// HierarchyWriter writes a Hierarchy to a target location.
+// Implementations should mirror the management group hierarchy on the target.
+type HierarchyWriter interface {
+	// Write exports the hierarchy to outDir. Each management group becomes a directory
+	// (nested according to parent/child), and each asset (policy assignment/definition,
+	// policy set definition, role definition) is written as a separate JSON file named
+	// using the asset JSON .name plus a type-specific suffix.
+	Write(ctx context.Context, h *Hierarchy, outDir string) error
+}
+
+// FSWriter writes a Hierarchy to the local filesystem.
+type FSWriter struct{}
+
+// NewFSWriter creates a new filesystem writer.
+func NewFSWriter() *FSWriter { return &FSWriter{} }
+
+const (
+	fileSuffixPolicyAssignment    = "." + processor.PolicyAssignmentFileType + ".json"
+	fileSuffixPolicyDefinition    = "." + processor.PolicyDefinitionFileType + ".json"
+	fileSuffixPolicySetDefinition = "." + processor.PolicySetDefinitionFileType + ".json"
+	fileSuffixRoleDefinition      = "." + processor.RoleDefinitionFileType + ".json"
+)
+
+const (
+	dirPerm          = 0o755
+	filePerm         = 0o644
+	controlCharLimit = 0x20
+)
+
+// Write implements HierarchyWriter.
+func (w *FSWriter) Write(ctx context.Context, h *Hierarchy, outDir string) error {
+	if h == nil {
+		return errors.New("fswriter.write: hierarchy is nil")
+	}
+
+	if strings.TrimSpace(outDir) == "" {
+		return errors.New("fswriter.write: outDir is empty")
+	}
+
+	if err := os.MkdirAll(outDir, dirPerm); err != nil {
+		return fmt.Errorf("fswriter.write: creating outDir: %w", err)
+	}
+
+	// Identify roots (Parent() == nil indicates internal parent is nil; external parents are still roots for file layout).
+	rootNames := make([]string, 0)
+
+	for _, name := range h.ManagementGroupNames() {
+		mg := h.ManagementGroup(name)
+		if mg == nil {
+			continue
+		}
+
+		if mg.Parent() == nil {
+			rootNames = append(rootNames, mg.Name())
+		}
+	}
+
+	sort.Strings(rootNames)
+
+	for _, root := range rootNames {
+		if err := w.writeMgmtGroupRecursive(ctx, h, root, outDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *FSWriter) writeMgmtGroupRecursive(ctx context.Context, h *Hierarchy, mgName, base string) error {
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
+
+	mg := h.ManagementGroup(mgName)
+	if mg == nil {
+		return fmt.Errorf("fswriter.writeMgmtGroupRecursive: management group %q not found", mgName)
+	}
+
+	// Directory path for this MG
+	dir := filepath.Join(base, sanitizeFilename(mg.Name()))
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("fswriter.writeMgmtGroupRecursive: creating dir %q: %w", dir, err)
+	}
+
+	// Write assets for this MG
+	if err := w.writePolicyAssignments(ctx, dir, mg); err != nil {
+		return err
+	}
+
+	if err := w.writePolicyDefinitions(ctx, dir, mg); err != nil {
+		return err
+	}
+
+	if err := w.writePolicySetDefinitions(ctx, dir, mg); err != nil {
+		return err
+	}
+
+	if err := w.writeRoleDefinitions(ctx, dir, mg); err != nil {
+		return err
+	}
+
+	// Recurse into children: stable order by child name
+	children := mg.Children()
+	sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
+
+	for _, child := range children {
+		if err := w.writeMgmtGroupRecursive(ctx, h, child.Name(), dir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *FSWriter) writePolicyAssignments(ctx context.Context, dir string, mg *HierarchyManagementGroup) error {
+	m := mg.PolicyAssignmentMap()
+	if len(m) == 0 {
+		return nil
+	}
+
+	list := make([]*assets.PolicyAssignment, 0, len(m))
+	for _, v := range m {
+		list = append(list, v)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return derefString(list[i].Name, "") < derefString(list[j].Name, "") })
+
+	for _, pa := range list {
+		if err := ctxErr(ctx); err != nil {
+			return err
+		}
+
+		assetName := derefString(pa.Name, "")
+
+		file := filepath.Join(dir, sanitizeFilename(assetName)+fileSuffixPolicyAssignment)
+		if err := writeJSONFile(file, pa); err != nil {
+			return fmt.Errorf("writing policy assignment %q: %w", assetName, err)
+		}
+	}
+
+	return nil
+}
+
+func (w *FSWriter) writePolicyDefinitions(ctx context.Context, dir string, mg *HierarchyManagementGroup) error {
+	m := mg.PolicyDefinitionsMap()
+	if len(m) == 0 {
+		return nil
+	}
+
+	list := make([]*assets.PolicyDefinition, 0, len(m))
+	for _, v := range m {
+		list = append(list, v)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return derefString(list[i].Name, "") < derefString(list[j].Name, "") })
+
+	for _, pd := range list {
+		if err := ctxErr(ctx); err != nil {
+			return err
+		}
+
+		assetName := derefString(pd.Name, "")
+
+		file := filepath.Join(dir, sanitizeFilename(assetName)+fileSuffixPolicyDefinition)
+		if err := writeJSONFile(file, pd); err != nil {
+			return fmt.Errorf("writing policy definition %q: %w", assetName, err)
+		}
+	}
+
+	return nil
+}
+
+func (w *FSWriter) writePolicySetDefinitions(ctx context.Context, dir string, mg *HierarchyManagementGroup) error {
+	m := mg.PolicySetDefinitionsMap()
+	if len(m) == 0 {
+		return nil
+	}
+
+	list := make([]*assets.PolicySetDefinition, 0, len(m))
+	for _, v := range m {
+		list = append(list, v)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return derefString(list[i].Name, "") < derefString(list[j].Name, "") })
+
+	for _, psd := range list {
+		if err := ctxErr(ctx); err != nil {
+			return err
+		}
+
+		assetName := derefString(psd.Name, "")
+
+		file := filepath.Join(dir, sanitizeFilename(assetName)+fileSuffixPolicySetDefinition)
+		if err := writeJSONFile(file, psd); err != nil {
+			return fmt.Errorf("writing policy set definition %q: %w", assetName, err)
+		}
+	}
+
+	return nil
+}
+
+func (w *FSWriter) writeRoleDefinitions(ctx context.Context, dir string, mg *HierarchyManagementGroup) error {
+	m := mg.RoleDefinitionsMap()
+	if len(m) == 0 {
+		return nil
+	}
+
+	list := make([]*assets.RoleDefinition, 0, len(m))
+	for _, v := range m {
+		list = append(list, v)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return derefString(list[i].Name, "") < derefString(list[j].Name, "") })
+
+	for _, rd := range list {
+		if err := ctxErr(ctx); err != nil {
+			return err
+		}
+
+		assetName := derefString(rd.Name, "")
+
+		file := filepath.Join(dir, sanitizeFilename(assetName)+fileSuffixRoleDefinition)
+		if err := writeJSONFile(file, rd); err != nil {
+			return fmt.Errorf("writing role definition %q: %w", assetName, err)
+		}
+	}
+
+	return nil
+}
+
+// Helpers
+
+// Note: sorting is now done on slices built from map values; helpers removed.
+
+func derefString(p *string, fallback string) string {
+	if p == nil || *p == "" {
+		return fallback
+	}
+
+	return *p
+}
+
+func sanitizeFilename(s string) string {
+	if s == "" {
+		return "unnamed"
+	}
+	// Replace path separators and common problematic characters; trim spaces.
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_", "?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+	)
+	s = replacer.Replace(s)
+	s = strings.Map(func(r rune) rune {
+		if r < controlCharLimit {
+			return '_' // control chars
+		}
+
+		return r
+	}, s)
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unnamed"
+	}
+
+	return s
+}
+
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+func writeJSONFile(finalPath string, v any) error {
+	dir := filepath.Dir(finalPath)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("create dir for %q: %w", finalPath, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tmp-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp file for %q: %w", finalPath, err)
+	}
+
+	tmpName := tmp.Name()
+	// Ensure cleanup on failure
+	defer func() { _ = os.Remove(tmpName) }()
+
+	enc := json.NewEncoder(tmp)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(v); err != nil { // adds a trailing newline which is fine
+		_ = tmp.Close()
+		return fmt.Errorf("encode json for %q: %w", finalPath, err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp for %q: %w", finalPath, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp for %q: %w", finalPath, err)
+	}
+
+	if err := os.Rename(tmpName, finalPath); err != nil {
+		return fmt.Errorf("rename temp to final for %q: %w", finalPath, err)
+	}
+
+	if err := os.Chmod(finalPath, filePerm); err != nil {
+		return fmt.Errorf("chmod final for %q: %w", finalPath, err)
+	}
+
+	return nil
+}

--- a/deployment/writer_fs.go
+++ b/deployment/writer_fs.go
@@ -47,6 +47,7 @@ func NewFSWriter(opts ...FSWriterOption) *FSWriter {
 	for _, opt := range opts {
 		opt(w)
 	}
+
 	return w
 }
 
@@ -334,6 +335,7 @@ func (w *FSWriter) writeJSONFileMaybeEscaped(ctx context.Context, finalPath stri
 	if err := ctxErr(ctx); err != nil {
 		return err
 	}
+
 	if !w.escapeARM {
 		return writeJSONFile(finalPath, v)
 	}
@@ -343,13 +345,16 @@ func (w *FSWriter) writeJSONFileMaybeEscaped(ctx context.Context, finalPath stri
 	if err != nil {
 		return fmt.Errorf("marshal for escaping: %w", err)
 	}
+
 	var m any
 	if err := json.Unmarshal(b, &m); err != nil {
 		return fmt.Errorf("unmarshal for escaping: %w", err)
 	}
+
 	if err := addArmFunctionEscaping(m); err != nil {
 		return fmt.Errorf("escape ARM functions: %w", err)
 	}
+
 	return writeJSONFile(finalPath, m)
 }
 func addArmFunctionEscaping(v any) error {

--- a/deployment/writer_fs_test.go
+++ b/deployment/writer_fs_test.go
@@ -97,7 +97,7 @@ func TestFSWriter_WithEscapeARM_Toggle(t *testing.T) {
 	require.NoError(t, wNoEsc.Write(context.Background(), h, outDirNoEsc))
 
 	outDirEsc := t.TempDir()
-	wEsc := NewFSWriter(WithEscapeARM(true))
+	wEsc := NewFSWriter(WithAlzBicepMode(true))
 	require.NoError(t, wEsc.Write(context.Background(), h, outDirEsc))
 
 	// Compare one known file content for evidence of escaping behavior.
@@ -188,7 +188,6 @@ func TestSanitizeFilename(t *testing.T) {
 func TestCtxErr(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, ctxErr(nil)) //nolint:staticcheck
 	require.NoError(t, ctxErr(context.Background()))
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/deployment/writer_fs_test.go
+++ b/deployment/writer_fs_test.go
@@ -112,12 +112,16 @@ func TestFSWriter_WithEscapeARM_Toggle(t *testing.T) {
 
 	// Parse into generic maps and scan for any string starting with "[[" in the escaped output,
 	// which should be strictly more than in the non-escaped output.
-	var noEsc any
-	var esc any
+	var (
+		noEsc any
+		esc   any
+	)
+
 	require.NoError(t, json.Unmarshal(noEscBytes, &noEsc))
 	require.NoError(t, json.Unmarshal(escBytes, &esc))
 
 	var countStarts func(v any) int
+
 	countStarts = func(v any) (count int) {
 		switch t := v.(type) {
 		case map[string]any:
@@ -133,6 +137,7 @@ func TestFSWriter_WithEscapeARM_Toggle(t *testing.T) {
 				count++
 			}
 		}
+
 		return
 	}
 

--- a/deployment/writer_fs_test.go
+++ b/deployment/writer_fs_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/alzlib"
+	"github.com/Azure/alzlib/assets"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSimpleHierarchy constructs a hierarchy from the testdata/simple library used elsewhere in tests.
+func buildSimpleHierarchy(t *testing.T) *Hierarchy {
+	t.Helper()
+	// Path from this package directory to repo testdata/simple
+	libPath := filepath.Join("..", "testdata", "simple")
+
+	// Ensure a clean local fetch workspace under current working directory used by the fetcher.
+	_ = os.RemoveAll(".alzlib")
+
+	t.Cleanup(func() { _ = os.RemoveAll(".alzlib") })
+
+	thislib := alzlib.NewCustomLibraryReference(libPath)
+	alllibs, err := thislib.FetchWithDependencies(context.Background())
+	require.NoError(t, err)
+
+	az := alzlib.NewAlzLib(nil)
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	require.NoError(t, err)
+	cf, err := armpolicy.NewClientFactory("", cred, nil)
+	require.NoError(t, err)
+	az.AddPolicyClient(cf)
+	require.NoError(t, az.Init(context.Background(), alllibs...))
+
+	h := NewHierarchy(az)
+	require.NoError(t, h.FromArchitecture(context.Background(), "simple", "00000000-0000-0000-0000-000000000000", "northeurope"))
+
+	return h
+}
+
+func TestFSWriter_ExportsSimple(t *testing.T) {
+	h := buildSimpleHierarchy(t)
+
+	outDir := t.TempDir()
+	w := NewFSWriter()
+	require.NoError(t, w.Write(context.Background(), h, outDir))
+
+	// Expect root MG directories from simple architecture
+	// Known MG ids from prior tests: "simple" and "simpleoverride"
+	mgDirs := []string{"simple", "simpleoverride"}
+	for _, mg := range mgDirs {
+		dir := filepath.Join(outDir, mg)
+		fi, err := os.Stat(dir)
+		require.NoError(t, err, "expected MG directory %s", dir)
+		require.True(t, fi.IsDir())
+	}
+
+	// Check a few known files in "simple" MG directory
+	simpleDir := filepath.Join(outDir, "simple")
+	// expected asset names from test library
+	expectFiles := []string{
+		"test-pa" + fileSuffixPolicyAssignment,
+		"test-policy-definition" + fileSuffixPolicyDefinition,
+		"test-policy-set-definition" + fileSuffixPolicySetDefinition,
+	}
+	for _, f := range expectFiles {
+		_, err := os.Stat(filepath.Join(simpleDir, f))
+		require.NoError(t, err, "expected file %s", f)
+	}
+
+	// Load a file and validate it unmarshals into the correct type and name matches
+	paPath := filepath.Join(simpleDir, "test-pa"+fileSuffixPolicyAssignment)
+	b, err := os.ReadFile(paPath)
+	require.NoError(t, err)
+
+	var pa assets.PolicyAssignment
+	require.NoError(t, json.Unmarshal(b, &pa))
+	require.NotNil(t, pa.Name)
+	require.Equal(t, "test-pa", *pa.Name)
+}
+
+func TestFSWriter_Cancellation(t *testing.T) {
+	h := buildSimpleHierarchy(t)
+	outDir := t.TempDir()
+	w := NewFSWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := w.Write(ctx, h, outDir)
+	require.Error(t, err)
+}
+
+func TestDerefString(t *testing.T) {
+	t.Parallel()
+
+	var nilPtr *string
+	require.Equal(t, "fallback", derefString(nilPtr, "fallback"))
+
+	empty := ""
+	require.Equal(t, "fallback", derefString(&empty, "fallback"))
+
+	val := "value"
+	require.Equal(t, "value", derefString(&val, "fallback"))
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	t.Parallel()
+
+	// empty and whitespace
+	require.Equal(t, "unnamed", sanitizeFilename(""))
+	require.Equal(t, "unnamed", sanitizeFilename("   "))
+
+	// safe name stays same
+	require.Equal(t, "my-file_name", sanitizeFilename("my-file_name"))
+
+	// invalid characters replaced, control chars mapped to '_'
+	in := "a/b\\c:d*e?f\"g<h>i|j\t\n"
+	out := sanitizeFilename(in)
+	require.Equal(t, "a_b_c_d_e_f_g_h_i_j__", out)
+}
+
+func TestCtxErr(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ctxErr(nil)) //nolint:staticcheck
+	require.NoError(t, ctxErr(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, ctxErr(ctx))
+}
+
+func TestWriteJSONFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "obj.json")
+
+	obj := struct {
+		X string `json:"x"`
+	}{X: "y"}
+
+	require.NoError(t, writeJSONFile(path, obj))
+
+	// file exists and contains valid JSON
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dec map[string]any
+	require.NoError(t, json.Unmarshal(b, &dec))
+	require.Equal(t, "y", dec["x"])
+}

--- a/deployment/writer_fs_test.go
+++ b/deployment/writer_fs_test.go
@@ -274,7 +274,7 @@ func TestAddArmFunctionEscaping_SliceRoot(t *testing.T) {
 	require.Equal(t, "[[deployment().name]", m["k"])
 }
 
-// Helper for tests in this file
+// Helper for tests in this file.
 func toPtr[T any](t T) *T { return &t }
 
 func TestUpdatePolicyDefinitionReferences(t *testing.T) {
@@ -291,7 +291,9 @@ func TestUpdatePolicyDefinitionReferences(t *testing.T) {
 		if pdrefs[0].PolicyDefinitionID == nil {
 			t.Fatalf("expected non-nil PolicyDefinitionID after update")
 		}
+
 		got := *pdrefs[0].PolicyDefinitionID
+
 		want := "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.Authorization/policyDefinitions/REPLACED"
 		if got != want {
 			t.Fatalf("unexpected result\ngot:  %s\nwant: %s", got, want)
@@ -326,7 +328,9 @@ func TestUpdatePolicyDefinitionReferences(t *testing.T) {
 		if pdrefs[0].PolicyDefinitionID == nil {
 			t.Fatalf("expected non-nil PolicyDefinitionID after update")
 		}
+
 		got := *pdrefs[0].PolicyDefinitionID
+
 		want := "prefix/Z-middle/Z-suffix"
 		if got != want {
 			t.Fatalf("unexpected multiple replacement\ngot:  %s\nwant: %s", got, want)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -15,20 +15,26 @@ import (
 
 	"github.com/Azure/alzlib/assets"
 	"github.com/Azure/alzlib/internal/environment"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
 )
 
 // These are the file prefixes for the resource types.
 const (
-	architectureDefinitionSuffix = ".+\\.alz_architecture_definition\\.(?:json|yaml|yml)$"
-	archetypeDefinitionSuffix    = ".+\\.alz_archetype_definition\\.(?:json|yaml|yml)$"
-	archetypeOverrideSuffix      = ".+\\.alz_archetype_override\\.(?:json|yaml|yml)$"
-	policyAssignmentSuffix       = ".+\\.alz_policy_assignment\\.(?:json|yaml|yml)$"
-	policyDefinitionSuffix       = ".+\\.alz_policy_definition\\.(?:json|yaml|yml)$"
-	policySetDefinitionSuffix    = ".+\\.alz_policy_set_definition\\.(?:json|yaml|yml)$"
-	roleDefinitionSuffix         = ".+\\.alz_role_definition\\.(?:json|yaml|yml)$"
-	policyDefaultValueFileName   = "^alz_policy_default_values\\.(?:json|yaml|yml)$"
+	PolicyAssignmentFileType       = "alz_policy_assignment"
+	PolicyDefinitionFileType       = "alz_policy_definition"
+	PolicySetDefinitionFileType    = "alz_policy_set_definition"
+	RoleDefinitionFileType         = "alz_role_definition"
+	ArchitectureDefinitionFileType = "alz_architecture_definition"
+	ArchetypeDefinitionFileType    = "alz_archetype_definition"
+	ArchetypeOverrideFileType      = "alz_archetype_override"
+	PolicyDefaultValuesFileType    = "alz_policy_default_values"
+	architectureDefinitionSuffix   = ".+\\." + ArchitectureDefinitionFileType + "\\.(?:json|yaml|yml)$"
+	archetypeDefinitionSuffix      = ".+\\." + ArchetypeDefinitionFileType + "\\.(?:json|yaml|yml)$"
+	archetypeOverrideSuffix        = ".+\\." + ArchetypeOverrideFileType + "\\.(?:json|yaml|yml)$"
+	policyAssignmentSuffix         = ".+\\." + PolicyAssignmentFileType + "\\.(?:json|yaml|yml)$"
+	policyDefinitionSuffix         = ".+\\." + PolicyDefinitionFileType + "\\.(?:json|yaml|yml)$"
+	policySetDefinitionSuffix      = ".+\\." + PolicySetDefinitionFileType + "\\.(?:json|yaml|yml)$"
+	roleDefinitionSuffix           = ".+\\." + RoleDefinitionFileType + "\\.(?:json|yaml|yml)$"
+	policyDefaultValueFileName     = "^" + PolicyDefaultValuesFileType + "\\.(?:json|yaml|yml)$"
 )
 
 const (
@@ -80,10 +86,10 @@ func NewErrorUnmarshaling(detail string) error {
 
 // Result is the structure that gets built by scanning the library files.
 type Result struct {
-	PolicyDefinitions                   map[string]*armpolicy.Definition
-	PolicySetDefinitions                map[string]*armpolicy.SetDefinition
+	PolicyDefinitions                   map[string]*assets.PolicyDefinition
+	PolicySetDefinitions                map[string]*assets.PolicySetDefinition
 	PolicyAssignments                   map[string]*assets.PolicyAssignment
-	RoleDefinitions                     map[string]*armauthorization.RoleDefinition
+	RoleDefinitions                     map[string]*assets.RoleDefinition
 	LibArchetypes                       map[string]*LibArchetype
 	LibArchetypeOverrides               map[string]*LibArchetypeOverride
 	LibDefaultPolicyValues              map[string]*LibDefaultPolicyValuesDefaults
@@ -95,10 +101,10 @@ type Result struct {
 // NewResult creates a new Result struct with initialized maps for each resource type.
 func NewResult() *Result {
 	return &Result{
-		PolicyDefinitions:                   make(map[string]*armpolicy.Definition),
-		PolicySetDefinitions:                make(map[string]*armpolicy.SetDefinition),
+		PolicyDefinitions:                   make(map[string]*assets.PolicyDefinition),
+		PolicySetDefinitions:                make(map[string]*assets.PolicySetDefinition),
 		PolicyAssignments:                   make(map[string]*assets.PolicyAssignment),
-		RoleDefinitions:                     make(map[string]*armauthorization.RoleDefinition),
+		RoleDefinitions:                     make(map[string]*assets.RoleDefinition),
 		LibArchetypes:                       make(map[string]*LibArchetype),
 		LibArchetypeOverrides:               make(map[string]*LibArchetypeOverride),
 		LibDefaultPolicyValues:              make(map[string]*LibDefaultPolicyValuesDefaults),
@@ -367,9 +373,9 @@ func processPolicyAssignment(res *Result, unmar unmarshaler) error {
 }
 
 // processPolicyAssignment is a processFunc that reads the policy_definition
-// bytes, processes, then adds the created armpolicy.Definition to the result.
+// bytes, processes, then adds the created assets.PolicyDefinition to the result.
 func processPolicyDefinition(res *Result, unmar unmarshaler) error {
-	pd := new(armpolicy.Definition)
+	pd := new(assets.PolicyDefinition)
 	if err := unmar.unmarshal(pd); err != nil {
 		return errors.Join(NewErrorUnmarshaling("policy definition"), err)
 	}
@@ -388,9 +394,9 @@ func processPolicyDefinition(res *Result, unmar unmarshaler) error {
 }
 
 // processPolicyAssignment is a processFunc that reads the policy_set_definition
-// bytes, processes, then adds the created armpolicy.SetDefinition to the result.
+// bytes, processes, then adds the created assets.PolicySetDefinition to the result.
 func processPolicySetDefinition(res *Result, unmar unmarshaler) error {
-	psd := new(armpolicy.SetDefinition)
+	psd := new(assets.PolicySetDefinition)
 	if err := unmar.unmarshal(psd); err != nil {
 		return errors.Join(NewErrorUnmarshaling("policy set definition"), err)
 	}
@@ -414,7 +420,7 @@ func processPolicySetDefinition(res *Result, unmar unmarshaler) error {
 // definition may be
 // deployed at multiple scopes.
 func processRoleDefinition(res *Result, unmar unmarshaler) error {
-	rd := new(armauthorization.RoleDefinition)
+	rd := new(assets.RoleDefinition)
 	if err := unmar.unmarshal(rd); err != nil {
 		return errors.Join(NewErrorUnmarshaling("role definition"), err)
 	}

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -146,7 +146,8 @@ func TestProcessPolicyAssignmentNoName(t *testing.T) {
 		PolicyAssignments: make(map[string]*assets.PolicyAssignment),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
-	assert.ErrorContains(t, processPolicyAssignment(res, unmar), "name must not be nil")
+	target := &assets.ErrPropertyMustNotBeNil{}
+	require.ErrorAs(t, processPolicyAssignment(res, unmar), &target)
 }
 
 // TestProcessPolicyDefinitionValid tests the processing of a valid policy definition.

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 
 	"github.com/Azure/alzlib/assets"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -156,7 +155,7 @@ func TestProcessPolicyDefinitionValid(t *testing.T) {
 
 	sampleData := getSamplePolicyDefinition()
 	res := &Result{
-		PolicyDefinitions: make(map[string]*armpolicy.Definition),
+		PolicyDefinitions: make(map[string]*assets.PolicyDefinition),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
 	require.NoError(t, processPolicyDefinition(res, unmar))
@@ -180,13 +179,14 @@ func TestProcessPolicyDefinitionNoName(t *testing.T) {
 
 	sampleData := getSamplePolicyDefinition_noName()
 	res := &Result{
-		PolicyDefinitions: make(map[string]*armpolicy.Definition),
+		PolicyDefinitions: make(map[string]*assets.PolicyDefinition),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
-	assert.ErrorIs(
+	target := &assets.ErrPropertyLength{}
+	assert.ErrorAs(
 		t,
 		processPolicyDefinition(res, unmar),
-		ErrNoNameProvided,
+		&target,
 	)
 }
 
@@ -196,7 +196,7 @@ func TestProcessSetPolicyDefinitionValid(t *testing.T) {
 
 	sampleData := getSamplePolicySetDefinition()
 	res := &Result{
-		PolicySetDefinitions: make(map[string]*armpolicy.SetDefinition),
+		PolicySetDefinitions: make(map[string]*assets.PolicySetDefinition),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
 	require.NoError(t, processPolicySetDefinition(res, unmar))
@@ -216,13 +216,14 @@ func TestProcessPolicySetDefinitionNoName(t *testing.T) {
 
 	sampleData := getSamplePolicySetDefinition_noName()
 	res := &Result{
-		PolicySetDefinitions: make(map[string]*armpolicy.SetDefinition),
+		PolicySetDefinitions: make(map[string]*assets.PolicySetDefinition),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
-	assert.ErrorIs(
+	target := &assets.ErrPropertyMustNotBeNil{}
+	assert.ErrorAs(
 		t,
 		processPolicySetDefinition(res, unmar),
-		ErrNoNameProvided,
+		&target,
 	)
 }
 
@@ -263,7 +264,7 @@ func TestProcessRoleDefinitionWithDataActions(t *testing.T) {
 
 	sampleData := getSampleRoleDefinitionWithDataActions()
 	res := &Result{
-		RoleDefinitions: make(map[string]*armauthorization.RoleDefinition),
+		RoleDefinitions: make(map[string]*assets.RoleDefinition),
 	}
 	unmar := newUnmarshaler(sampleData, ".json")
 	require.NoError(t, processRoleDefinition(res, unmar))

--- a/internal/tools/checks/checkDefaults_test.go
+++ b/internal/tools/checks/checkDefaults_test.go
@@ -16,7 +16,7 @@ func TestCheckDefaultsGood(t *testing.T) {
 	az := alzlib.NewAlzLib(nil)
 	ctx := context.Background()
 	lib := alzlib.NewCustomLibraryReference("testdata/defaultsgood")
-	_, err := lib.Fetch(ctx, "0")
+	_, err := lib.Fetch(ctx, t.Name())
 	require.NoError(t, err)
 	require.NoError(t, az.Init(ctx, lib))
 	require.NoError(t, checkDefaults(az))
@@ -26,7 +26,7 @@ func TestCheckDefaultsAssignmentNotPresent(t *testing.T) {
 	az := alzlib.NewAlzLib(nil)
 	ctx := context.Background()
 	lib := alzlib.NewCustomLibraryReference("testdata/defaultsassignmentnotpresent")
-	_, err := lib.Fetch(ctx, "0")
+	_, err := lib.Fetch(ctx, t.Name())
 	require.NoError(t, err)
 	require.NoError(t, az.Init(ctx, lib))
 	assert.ErrorContains(
@@ -40,7 +40,7 @@ func TestCheckDefaultsParameterNotPresent(t *testing.T) {
 	az := alzlib.NewAlzLib(nil)
 	ctx := context.Background()
 	lib := alzlib.NewCustomLibraryReference("testdata/defaultsparameternotpresent")
-	_, err := lib.Fetch(ctx, "0")
+	_, err := lib.Fetch(ctx, t.Name())
 	require.NoError(t, err)
 	require.NoError(t, az.Init(ctx, lib))
 	assert.ErrorContains(

--- a/internal/tools/checks/testdata/defaultsparameternotpresent/test
+++ b/internal/tools/checks/testdata/defaultsparameternotpresent/test
@@ -1,0 +1,1 @@
+/Volumes/code/alzlib/internal/tools/checks/testdata/defaultsparameternotpresent


### PR DESCRIPTION
This pull request introduces improved validation and error handling for policy-related asset types, along with some related refactoring and minor configuration changes. The primary focus is on adding structured, reusable error types for property validation and refactoring validation logic for policy definitions, policy set definitions, and policy assignments to use these new error types. Additionally, the code for constructing these asset types is updated to support validation, and related unit tests are updated accordingly.

**Validation and Error Handling Improvements:**

* Introduced new structured error types (`ErrPropertyMustNotBeNil` and `ErrPropertyLength`) in `assets/errors.go` to provide more descriptive and reusable validation errors for asset properties.
* Refactored validation logic in `assets/policyAssignment.go` to use the new error types for nil and length checks, replacing generic error strings. [[1]](diffhunk://#diff-b15b38e6e358b553d4149961b26be7d70245768fbac5ae4e63d0812e0405eec4L111-R114) [[2]](diffhunk://#diff-b15b38e6e358b553d4149961b26be7d70245768fbac5ae4e63d0812e0405eec4L127-R157)
* Updated validation logic for `PolicyDefinition` and `PolicyDefinitionVersion` in `assets/policyDefinition.go` and `assets/policyDefinitionVersion.go` to use the new error types and added `ValidatePolicyDefinition`, `ValidatePolicyDefinitionVersion`, and corresponding constructor functions that perform validation. [[1]](diffhunk://#diff-19be9125bbd0d0385415d17886a992136c98837799d65936611b4b56990902e1R39-R49) [[2]](diffhunk://#diff-19be9125bbd0d0385415d17886a992136c98837799d65936611b4b56990902e1R237-R327) [[3]](diffhunk://#diff-75462c7f34f075a3098fb8e25d257b71576182e43768e9cb89a58eb2d461fb67R28-R38) [[4]](diffhunk://#diff-75462c7f34f075a3098fb8e25d257b71576182e43768e9cb89a58eb2d461fb67R223-R313)
* Added similar validation and constructor for `PolicySetDefinition`, including a new name length constant. [[1]](diffhunk://#diff-0e26d463d3e4c4a76af6a904ed21b89c4b85e3c7ff116b0dadd5fc3a020afe60R20-R21) [[2]](diffhunk://#diff-0e26d463d3e4c4a76af6a904ed21b89c4b85e3c7ff116b0dadd5fc3a020afe60R36-R45)

**Test and Usage Updates:**

* Updated unit tests in `assets/policyAssignment_test.go` to expect the new error message formats from the structured error types. [[1]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L133-R133) [[2]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L154-R154) [[3]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L165-R165) [[4]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L178-R178) [[5]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L192-R192) [[6]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L205-R205) [[7]](diffhunk://#diff-c09e3179be40460b6fd259c39d3c484a3585167a21fb9f1dc92a3b5f10401246L219-R219)
* Modified `alzlib.go` to stop wrapping policy asset types with constructors (e.g., `assets.NewPolicyDefinition(*v)`), instead storing the objects directly, likely because validation is now handled elsewhere. [[1]](diffhunk://#diff-53d41e1c188fb0d2bc11e769f8bfd4a91e1ef32a277277db3e9f45cdd92ffd3eL847-R847) [[2]](diffhunk://#diff-53d41e1c188fb0d2bc11e769f8bfd4a91e1ef32a277277db3e9f45cdd92ffd3eL858-R858) [[3]](diffhunk://#diff-53d41e1c188fb0d2bc11e769f8bfd4a91e1ef32a277277db3e9f45cdd92ffd3eL880-R880)

**Configuration and Miscellaneous:**

* Refactored the `.goreleaser.yml` configuration for `alzlibtool` archives to use `formats` and `ids` for consistency and clarity.
* Removed an unnecessary assertion from `alzlib_test.go` to align with the updated asset handling.
* Minor import and constant additions for clarity and maintainability. [[1]](diffhunk://#diff-b15b38e6e358b553d4149961b26be7d70245768fbac5ae4e63d0812e0405eec4L7) [[2]](diffhunk://#diff-19be9125bbd0d0385415d17886a992136c98837799d65936611b4b56990902e1R10-R27) [[3]](diffhunk://#diff-75462c7f34f075a3098fb8e25d257b71576182e43768e9cb89a58eb2d461fb67R10) [[4]](diffhunk://#diff-0e26d463d3e4c4a76af6a904ed21b89c4b85e3c7ff116b0dadd5fc3a020afe60R20-R21)

These changes make property validation more robust, error reporting more consistent, and asset construction safer and easier to maintain.