### PR TITLE
fix: properly configure policy client for clouds

### DIFF
--- a/cmd/alzlibtool/command/check/library.go
+++ b/cmd/alzlibtool/command/check/library.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Azure/alzlib/internal/auth"
 	"github.com/Azure/alzlib/internal/tools/checker"
 	"github.com/Azure/alzlib/internal/tools/checks"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +29,11 @@ var libraryCmd = cobra.Command{
 			cmd.PrintErrf("%s could not get Azure credential: %v\n", cmd.ErrPrefix(), err)
 			os.Exit(1)
 		}
-		cf, err := armpolicy.NewClientFactory("", creds, nil)
+		cf, err := armpolicy.NewClientFactory("", creds, &arm.ClientOptions{
+			ClientOptions: policy.ClientOptions{
+				Cloud: auth.GetCloudFromEnv(),
+			},
+		})
 		if err != nil {
 			cmd.PrintErrf("%s could not create Azure policy client factory: %v\n", cmd.ErrPrefix(), err)
 			os.Exit(1)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,9 +19,10 @@ var environmentToCloud = map[string]cloud.Configuration{
 	"china":        cloud.AzureChina,
 }
 
-// NewToken creates a new Entra token credential.
-// It uses well-known Terraform ARM environment variables to configure the token acquisition.
-func NewToken() (azcore.TokenCredential, error) {
+// GetCloudFromEnv retrieves the Azure cloud configuration based on environment variables.
+// It checks the ARM_ENVIRONMENT and AZURE_ENVIRONMENT variables to determine the appropriate cloud.
+// If neither variable is set or recognized, it defaults to AzurePublic.
+func GetCloudFromEnv() cloud.Configuration {
 	cld := cloud.AzurePublic
 
 	if env := getFirstSetEnvVar("ARM_ENVIRONMENT", "AZURE_ENVIRONMENT"); env != "" {
@@ -30,10 +31,16 @@ func NewToken() (azcore.TokenCredential, error) {
 		}
 	}
 
+	return cld
+}
+
+// NewToken creates a new Entra token credential.
+// It uses well-known Terraform ARM environment variables to configure the token acquisition.
+func NewToken() (azcore.TokenCredential, error) {
 	opts := aztfauth.Option{
 		UseAzureCLI: true,
 		ClientOptions: azcore.ClientOptions{
-			Cloud: cld,
+			Cloud: GetCloudFromEnv(),
 		},
 	}
 


### PR DESCRIPTION
This pull request updates the Azure cloud environment handling in both the check and architecture generation commands, ensuring that the correct cloud configuration is used based on environment variables. It also improves naming consistency and introduces minor refactoring for clarity. The most important changes are grouped below.

**Cloud Environment Configuration Updates:**

* Added imports for `arm` and `policy` packages in `library.go` and `architecture.go` to support explicit cloud configuration when creating Azure clients. [[1]](diffhunk://#diff-be945ead629f2ed0358b1fbb2a53af2a8d9c456b965da197c9d2cb06ff3fe423R13-R14) [[2]](diffhunk://#diff-117ab0079f5c8f0519f436760f473ae25566bfffc40ae4e3bc8f566714bcd628R15-R16)
* Updated the creation of `armpolicy.ClientFactory` in both commands to use a new `arm.ClientOptions` that sets the cloud based on environment variables, using the new `auth.GetCloudFromEnv()` helper. [[1]](diffhunk://#diff-be945ead629f2ed0358b1fbb2a53af2a8d9c456b965da197c9d2cb06ff3fe423L30-R36) [[2]](diffhunk://#diff-117ab0079f5c8f0519f436760f473ae25566bfffc40ae4e3bc8f566714bcd628L42-R59)
* Refactored `auth.go` to introduce the `GetCloudFromEnv()` function, which determines the Azure cloud configuration from environment variables (`ARM_ENVIRONMENT` or `AZURE_ENVIRONMENT`).
* Updated `NewToken()` in `auth.go` to use `GetCloudFromEnv()` for setting the cloud in its client options, ensuring consistent environment-based configuration.

**Naming and Minor Refactoring:**

* Improved variable naming in `architecture.go` for clarity (`thisLib`/`allLibs` instead of `thislib`/`alllibs`). [[1]](diffhunk://#diff-117ab0079f5c8f0519f436760f473ae25566bfffc40ae4e3bc8f566714bcd628L31-R34) [[2]](diffhunk://#diff-117ab0079f5c8f0519f436760f473ae25566bfffc40ae4e3bc8f566714bcd628L42-R59)

fixes Azure/Azure-Landing-Zones#1492
