### PR TITLE
fix: make nil report as no error & add test for duplicate version.

### DIFF
--- a/alzlib.go
+++ b/alzlib.go
@@ -1203,6 +1203,7 @@ func (az *AlzLib) addPolicyAndRoleAssets(res *processor.Result) error {
 			if err := v.Upsert(pdv, az.Options.AllowOverwrite); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("policy definition %s: %w", k, err))
 			}
+
 			continue
 		}
 
@@ -1220,6 +1221,7 @@ func (az *AlzLib) addPolicyAndRoleAssets(res *processor.Result) error {
 			if err := v.Upsert(psdv, az.Options.AllowOverwrite); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("policy set definition %s: %w", k, err))
 			}
+
 			continue
 		}
 

--- a/alzlib_test.go
+++ b/alzlib_test.go
@@ -1129,7 +1129,9 @@ func TestIntegrationGetDefinitionsFromAzure(t *testing.T) {
 
 func testPolicyDefinition(t *testing.T, name, version string) *assets.PolicyDefinition {
 	t.Helper()
+
 	desc := name + " description"
+
 	return &assets.PolicyDefinition{
 		Definition: armpolicy.Definition{
 			Name: to.Ptr(name),
@@ -1146,7 +1148,9 @@ func testPolicyDefinition(t *testing.T, name, version string) *assets.PolicyDefi
 
 func testPolicySetDefinition(t *testing.T, name, version string) *assets.PolicySetDefinition {
 	t.Helper()
+
 	desc := name + " description"
+
 	return &assets.PolicySetDefinition{
 		SetDefinition: armpolicy.SetDefinition{
 			Name: to.Ptr(name),


### PR DESCRIPTION
This PR replaces #225 to enable CI/CD checks with required secrets.

Original PR by @kewalaka

---

This pull request improves error handling and test coverage for the `addPolicyAndRoleAssets` method in `alzlib.go`, ensuring that duplicate policy and policy set definition versions are handled correctly. The changes refactor how errors are accumulated and reported, and add targeted unit tests for duplicate version scenarios.

**Error handling improvements:**

* Refactored error accumulation in `addPolicyAndRoleAssets` to use `multierror.Append` for both policy definitions and policy set definitions, ensuring errors are wrapped with descriptive context and reported correctly.

**Testing enhancements:**

* Added the `TestAddPolicyAndRoleAssetsAllowsDuplicateVersions` unit test to verify that adding duplicate versions of policy and policy set definitions works as expected, both when overwriting is allowed and disallowed.
* Introduced helper functions `testPolicyDefinition` and `testPolicySetDefinition` to simplify test setup for policy assets.

fixes: https://github.com/Azure/terraform-provider-alz/issues/188 
& https://github.com/Azure/terraform-provider-alz/issues/189