### PR TITLE
feat: Add proper validation for non-compliance messages in policy assignments

### DIFF
--- a/assets/policyAssignment.go
+++ b/assets/policyAssignment.go
@@ -193,19 +193,25 @@ func ValidatePolicyAssignment(pa *PolicyAssignment) error {
 	var defaultNonComplianceMessageCount int
 
 	for _, msg := range pa.Properties.NonComplianceMessages {
+		if msg == nil {
+			return fmt.Errorf(
+				"ValidatePolicyAssignment: policy assignment %s has a nil non-compliance message entry",
+				*pa.Name,
+			)
+		}
+
 		if msg.PolicyDefinitionReferenceID == nil || *msg.PolicyDefinitionReferenceID == "" {
 			defaultNonComplianceMessageCount++
 			if defaultNonComplianceMessageCount > 1 {
-			  break
+				break
 			}
 		}
 	}
 
 	if defaultNonComplianceMessageCount > 1 {
 		return fmt.Errorf(
-			"ValidatePolicyAssignment: policy assignment %s has %d default non-compliance messages, only 1 is allowed",
+			"ValidatePolicyAssignment: policy assignment %s has more than 1 default non-compliance messages, only 1 is allowed",
 			*pa.Name,
-			defaultNonComplianceMessageCount,
 		)
 	}
 

--- a/assets/policyAssignment.go
+++ b/assets/policyAssignment.go
@@ -186,6 +186,26 @@ func ValidatePolicyAssignment(pa *PolicyAssignment) error {
 		pa.Properties.Overrides = make([]*armpolicy.Override, 0)
 	}
 
+	if pa.Properties.NonComplianceMessages == nil {
+		pa.Properties.NonComplianceMessages = make([]*armpolicy.NonComplianceMessage, 0)
+	}
+
+	var defaultNonComplianceMessageCount int
+
+	for _, msg := range pa.Properties.NonComplianceMessages {
+		if msg.PolicyDefinitionReferenceID == nil || *msg.PolicyDefinitionReferenceID == "" {
+			defaultNonComplianceMessageCount++
+		}
+	}
+
+	if defaultNonComplianceMessageCount > 1 {
+		return fmt.Errorf(
+			"ValidatePolicyAssignment: policy assignment %s has %d default non-compliance messages, only 1 is allowed",
+			*pa.Name,
+			defaultNonComplianceMessageCount,
+		)
+	}
+
 	if pa.Properties.Parameters == nil {
 		pa.Properties.Parameters = make(map[string]*armpolicy.ParameterValuesValue)
 	}

--- a/assets/policyAssignment.go
+++ b/assets/policyAssignment.go
@@ -195,6 +195,9 @@ func ValidatePolicyAssignment(pa *PolicyAssignment) error {
 	for _, msg := range pa.Properties.NonComplianceMessages {
 		if msg.PolicyDefinitionReferenceID == nil || *msg.PolicyDefinitionReferenceID == "" {
 			defaultNonComplianceMessageCount++
+			if defaultNonComplianceMessageCount > 1 {
+			  break
+			}
 		}
 	}
 

--- a/assets/policyAssignment_test.go
+++ b/assets/policyAssignment_test.go
@@ -252,7 +252,7 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "has 2 default non-compliance messages, only 1 is allowed",
+			expectedErr: "has more than 1 default non-compliance messages, only 1 is allowed",
 		},
 		{
 			name: "Multiple default non-compliance messages with empty reference ID",
@@ -270,7 +270,25 @@ func TestValidatePolicyAssignment(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "has 2 default non-compliance messages, only 1 is allowed",
+			expectedErr: "has more than 1 default non-compliance messages, only 1 is allowed",
+		},
+		{
+			name: "Nil element in non-compliance messages slice",
+			assignment: armpolicy.Assignment{
+				Name: to.Ptr("validName"),
+				Properties: &armpolicy.AssignmentProperties{
+					PolicyDefinitionID: to.Ptr(
+						"/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Authorization/policyDefinitions/pd1",
+					),
+					DisplayName: to.Ptr("Valid Display Name"),
+					Description: to.Ptr("Valid Description"),
+					NonComplianceMessages: []*armpolicy.NonComplianceMessage{
+						nil,
+						{Message: to.Ptr("ref message"), PolicyDefinitionReferenceID: to.Ptr("ref1")},
+					},
+				},
+			},
+			expectedErr: "has a nil non-compliance message entry",
 		},
 	}
 

--- a/assets/policyAssignment_test.go
+++ b/assets/policyAssignment_test.go
@@ -218,6 +218,60 @@ func TestValidatePolicyAssignment(t *testing.T) {
 			},
 			expectedErr: "property 'properties.description' length must be between 1 and 512, but is 0",
 		},
+		{
+			name: "Single default non-compliance message",
+			assignment: armpolicy.Assignment{
+				Name: to.Ptr("validName"),
+				Properties: &armpolicy.AssignmentProperties{
+					PolicyDefinitionID: to.Ptr(
+						"/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Authorization/policyDefinitions/pd1",
+					),
+					DisplayName: to.Ptr("Valid Display Name"),
+					Description: to.Ptr("Valid Description"),
+					NonComplianceMessages: []*armpolicy.NonComplianceMessage{
+						{Message: to.Ptr("default message")},
+						{Message: to.Ptr("ref message"), PolicyDefinitionReferenceID: to.Ptr("ref1")},
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Multiple default non-compliance messages",
+			assignment: armpolicy.Assignment{
+				Name: to.Ptr("validName"),
+				Properties: &armpolicy.AssignmentProperties{
+					PolicyDefinitionID: to.Ptr(
+						"/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Authorization/policyDefinitions/pd1",
+					),
+					DisplayName: to.Ptr("Valid Display Name"),
+					Description: to.Ptr("Valid Description"),
+					NonComplianceMessages: []*armpolicy.NonComplianceMessage{
+						{Message: to.Ptr("default message 1")},
+						{Message: to.Ptr("default message 2")},
+					},
+				},
+			},
+			expectedErr: "has 2 default non-compliance messages, only 1 is allowed",
+		},
+		{
+			name: "Multiple default non-compliance messages with empty reference ID",
+			assignment: armpolicy.Assignment{
+				Name: to.Ptr("validName"),
+				Properties: &armpolicy.AssignmentProperties{
+					PolicyDefinitionID: to.Ptr(
+						"/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Authorization/policyDefinitions/pd1",
+					),
+					DisplayName: to.Ptr("Valid Display Name"),
+					Description: to.Ptr("Valid Description"),
+					NonComplianceMessages: []*armpolicy.NonComplianceMessage{
+						{Message: to.Ptr("default message 1")},
+						{Message: to.Ptr("default message 2"), PolicyDefinitionReferenceID: to.Ptr("")},
+					},
+				},
+			},
+			expectedErr: "has 2 default non-compliance messages, only 1 is allowed",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adding validation logic to ensure that a policy assignment contains at most one default non-compliance message (a message without a `PolicyDefinitionReferenceID`). 

Supports [#201](https://github.com/Azure/terraform-provider-alz/pull/201)