### PR TITLE
Skip empty scopes in the policy set branch to align the behavior with…

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -50,7 +50,16 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          # This selects the golangci-lint binary and is independent of the action version above,
+          # which was upgraded to v9 to use the Node.js 24 runtime.
+          # Keep v2.11.4 pinned because it is the last known-good version for this codebase.
+          # Starting with v2.12.0, the upgraded goconst linter performs extended detection and
+          # reports 77 pre-existing repeated-string findings, mainly in test fixtures.
+          # Do not change this to `latest`, as that makes CI behavior change without repository changes.
+          # Upgrade the linter in a dedicated PR after reviewing the v2.12+ changelog and deciding
+          # whether to fix the findings or explicitly configure goconst (for example, ignore-tests).
+          # Changelog: https://golangci-lint.run/docs/product/changelog/#2120
+          version: v2.11.4
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -36,9 +36,9 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -47,7 +47,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/deployment/managementgroup.go
+++ b/deployment/managementgroup.go
@@ -626,6 +626,15 @@ func (mg *HierarchyManagementGroup) generatePolicyAssignmentAdditionalRoleAssign
 
 						continue
 					}
+					
+					// An assignPermissions parameter whose effective value is empty (e.g. a member
+					// policy added by an upstream version bump whose parameter defaults to "" and is
+					// not overridden by the assignment) has no scope to grant permissions on.
+					// Skip it — consistent with the standalone policy definition branch above.
+					if scopeStr == "" {
+						continue
+					}
+
 					// The value should be an ARM resource ID.
 					resid, err := arm.ParseResourceID(scopeStr)
 					if err != nil {

--- a/deployment/managementgroup_test.go
+++ b/deployment/managementgroup_test.go
@@ -58,6 +58,7 @@ func TestGeneratePolicyAssignmentAdditionalRoleAssignments(t *testing.T) {
 		Identity: &armpolicy.Identity{Type: to.Ptr(armpolicy.ResourceIdentityTypeSystemAssigned)},
 		Properties: &armpolicy.AssignmentProperties{
 			PolicyDefinitionID: to.Ptr("/providers/Microsoft.Authorization/policySetDefinitions/test-policy-set-definition"),
+			// setparameter3 is intentionally omitted so the policy set's empty default is used.
 			Parameters: map[string]*armpolicy.ParameterValuesValue{
 				"setparameter1": {Value: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg"},
 				"setparameter2": {Value: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg2"},
@@ -76,6 +77,10 @@ func TestGeneratePolicyAssignmentAdditionalRoleAssignments(t *testing.T) {
 				"setparameter2": {
 					Type: to.Ptr(armpolicy.ParameterTypeString),
 				},
+				"setparameter3": {
+					Type:         to.Ptr(armpolicy.ParameterTypeString),
+					DefaultValue: "",
+				},
 			},
 			PolicyDefinitions: []*armpolicy.DefinitionReference{
 				{
@@ -84,6 +89,7 @@ func TestGeneratePolicyAssignmentAdditionalRoleAssignments(t *testing.T) {
 					Parameters: map[string]*armpolicy.ParameterValuesValue{
 						"parameter1": {Value: "[parameters('setparameter1')]"},
 						"parameter2": {Value: "[parameters('setparameter2')]"},
+						"parameter3": {Value: "[parameters('setparameter3')]"},
 					},
 				},
 			},
@@ -161,6 +167,12 @@ func TestGeneratePolicyAssignmentAdditionalRoleAssignments(t *testing.T) {
 						AssignPermissions: to.Ptr(false),
 					},
 				},
+				"parameter3": {
+					Type: to.Ptr(armpolicy.ParameterTypeString),
+					Metadata: &armpolicy.ParameterDefinitionsValueMetadata{
+						AssignPermissions: to.Ptr(true),
+					},
+				},
 			},
 		},
 	})
@@ -191,6 +203,10 @@ func TestGeneratePolicyAssignmentAdditionalRoleAssignments(t *testing.T) {
 
 	// check that the additional role assignments were generated correctly.
 	assert.Equal(t, 4, mg.policyRoleAssignments.Cardinality())
+
+	for roleAssignment := range mg.policyRoleAssignments.Iter() {
+		assert.NotEmpty(t, roleAssignment.Scope)
+	}
 
 	assert.True(t, mg.policyRoleAssignments.Contains(PolicyRoleAssignment{
 		AssignmentName:   *paDef.Name,


### PR DESCRIPTION
## 1. Fix the issue: https://github.com/Azure/Azure-Landing-Zones/issues/4190

- Problem: A policy set member may contain a parameter with assignPermissions: true whose resolved value is an empty string. The PolicySetDefinitionsType branch attempted to parse this empty value as an ARM resource ID, resulting in: invalid resource ID: id cannot be empty. The policy definition branch already skips empty parameter values, but the policy set branch did not.

- Fix: Added an empty-value guard in the PolicySetDefinitionsType branch before calling arm.ParseResourceID(). Empty scopes are now skipped because there is no target resource on which to create a role assignment.
This aligns policy set behavior with the existing policy definition behavior while preserving validation errors for non-empty invalid resource IDs.

## 2. Fix Lint code base issue:
- Update Node.js version 

  Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24, For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
    - actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683, 
    - actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32, 
    - golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa. 
  
- golangci-lint is pinned to v2.11.4

   This PR upgrades the GitHub Actions used by the lint workflow to versions that run on Node.js 24:
    - `actions/checkout` v5.0.1
    - `actions/setup-go` v6.5.0
    - `golangci/golangci-lint-action` v9.3.0
   
   The `golangci/golangci-lint-action` version and its `version` input control two independent components:
    - The action version controls the GitHub Action implementation and its Node.js runtime.
    - The `version` input controls the downloaded `golangci-lint` binary and its linting behavior. 
  
  Previously, `version: latest` resolved to v2.11.4. After golangci-lint v2.12 was released, the same workflow started resolving to v2.12.2. Version v2.12 upgraded `goconst` and introduced extended detection, which exposed 77 pre-existing repeated-string findings, primarily in test fixtures. These findings are unrelated to the Node.js 24 migration.
  To keep this PR focused and make the CI result reproducible, the linter binary is pinned to the last known-good version: version: v2.11.4


