### PR TITLE
fix(processor): honour json struct tags when unmarshalling YAML

### DIFF
--- a/internal/processor/unmarshaler.go
+++ b/internal/processor/unmarshaler.go
@@ -47,6 +47,61 @@ func unmarshalJSON(data []byte, dst any) error {
 	return json.Unmarshal(data, dst) //nolint:wrapcheck
 }
 
+// unmarshalYAML converts the YAML document to JSON before unmarshalling it into dst.
+//
+// This indirection is deliberate. Many destination types are Azure SDK models
+// (e.g. armauthorization.RoleDefinition), which declare only `json:"..."` struct tags and
+// implement custom json.Unmarshaler methods keyed on the exact ARM field names. Decoding
+// YAML straight into those types silently produces empty values, because gopkg.in/yaml.v3
+// neither honours `json` tags nor invokes json.Unmarshaler. Round-tripping through JSON
+// makes the YAML and JSON code paths behave identically.
 func unmarshalYAML(data []byte, dst any) error {
-	return yaml.Unmarshal(data, dst) //nolint:wrapcheck
+	var raw any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshaler.unmarshalYAML: yaml.Unmarshal error: %w", err)
+	}
+
+	jsonBytes, err := json.Marshal(normalizeYAMLToJSON(raw))
+	if err != nil {
+		return fmt.Errorf("unmarshaler.unmarshalYAML: json.Marshal error: %w", err)
+	}
+
+	return unmarshalJSON(jsonBytes, dst)
+}
+
+// normalizeYAMLToJSON makes a decoded YAML value safe to marshal as JSON.
+//
+// yaml.v3 decodes a mapping into map[string]interface{} only when every key is a string;
+// otherwise it yields map[interface{}]interface{}, which encoding/json cannot marshal.
+// Converting those keys with fmt.Sprint mirrors how the same document would be written in
+// JSON, where object keys are always strings.
+func normalizeYAMLToJSON(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for key, val := range v {
+			result[key] = normalizeYAMLToJSON(val)
+		}
+
+		return result
+
+	case map[any]any:
+		result := make(map[string]any, len(v))
+		for key, val := range v {
+			result[fmt.Sprint(key)] = normalizeYAMLToJSON(val)
+		}
+
+		return result
+
+	case []any:
+		result := make([]any, len(v))
+		for i, val := range v {
+			result[i] = normalizeYAMLToJSON(val)
+		}
+
+		return result
+
+	default:
+		return value
+	}
 }

--- a/internal/processor/unmarshaler_test.go
+++ b/internal/processor/unmarshaler_test.go
@@ -254,3 +254,23 @@ properties:
 	assert.Contains(t, *pa.Properties.PolicyDefinitionID, "test-policy-set-definition")
 	assert.Contains(t, pa.Properties.Parameters, "effect")
 }
+
+func TestUnmarshalYamlInvalidDocument(t *testing.T) {
+	invalid := []byte("a:\n  - b\n c: d\n")
+
+	dst := new(assets.RoleDefinition)
+	err := NewUnmarshaler(invalid, ".yaml").Unmarshal(dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "yaml.Unmarshal error")
+}
+
+func TestUnmarshalYamlUnrepresentableInJson(t *testing.T) {
+	// NaN is a valid YAML float but has no JSON representation, so the conversion to JSON
+	// must fail rather than silently producing an invalid document.
+	notANumber := []byte("value: .nan\n")
+
+	dst := new(map[string]any)
+	err := NewUnmarshaler(notANumber, ".yaml").Unmarshal(dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json.Marshal error")
+}

--- a/internal/processor/unmarshaler_test.go
+++ b/internal/processor/unmarshaler_test.go
@@ -6,6 +6,8 @@ package processor
 import (
 	"testing"
 
+	"github.com/Azure/alzlib/assets"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +40,217 @@ age: 30
 
 		require.NoError(t, err)
 		assert.Equal(t, "John", dst["name"])
-		assert.Equal(t, int(30), dst["age"])
+		// YAML is routed through JSON so that `json` struct tags and json.Unmarshaler
+		// implementations are honoured. A side effect is that numbers decoded into an
+		// untyped destination arrive as float64 rather than int, matching the JSON path
+		// exactly. Typed destinations are unaffected.
+		assert.InEpsilon(t, float64(30), dst["age"], 0.01)
 	}
+}
+
+// TestUnmarshalYamlJsonParity asserts the property the fix is really about: equivalent
+// YAML and JSON documents must produce identical results.
+func TestUnmarshalYamlJsonParity(t *testing.T) {
+	yamlData := []byte("name: John\nage: 30\nnested:\n  values:\n    - 1\n    - 2\n")
+	jsonData := []byte(`{"name":"John","age":30,"nested":{"values":[1,2]}}`)
+
+	var fromYAML, fromJSON map[string]interface{}
+
+	require.NoError(t, NewUnmarshaler(yamlData, ".yaml").Unmarshal(&fromYAML))
+	require.NoError(t, NewUnmarshaler(jsonData, ".json").Unmarshal(&fromJSON))
+
+	assert.Equal(t, fromJSON, fromYAML)
+}
+
+// TestUnmarshalYamlNonStringKeys covers the normalizeYAMLToJSON helper. yaml.v3 decodes a
+// mapping with non-string keys into map[interface{}]interface{}, which encoding/json
+// cannot marshal; the helper converts those keys the way JSON would represent them.
+func TestUnmarshalYamlNonStringKeys(t *testing.T) {
+	data := []byte("1: one\n2: two\n")
+
+	var dst map[string]interface{}
+
+	require.NoError(t, NewUnmarshaler(data, ".yaml").Unmarshal(&dst))
+	assert.Equal(t, "one", dst["1"])
+	assert.Equal(t, "two", dst["2"])
+}
+
+// The tests below unmarshal into typed structs rather than map[string]interface{}.
+// Struct tags are irrelevant when the destination is a map, which is why the existing
+// tests above passed while YAML parsing of typed assets was broken.
+
+// TestUnmarshalYamlIntoTypedStructRoleDefinition covers issue #4225: a YAML role
+// definition using the documented camelCase keys must populate the typed struct
+// identically to its JSON equivalent.
+func TestUnmarshalYamlIntoTypedStructRoleDefinition(t *testing.T) {
+	yamlData := []byte(`
+name: 00000000-0000-0000-0000-000000000001
+type: Microsoft.Authorization/roleDefinitions
+properties:
+  roleName: Test-Role-Definition
+  description: A test role definition.
+  assignableScopes:
+    - /providers/Microsoft.Management/managementGroups/placeholder
+  permissions:
+    - actions:
+        - Microsoft.Resources/subscriptions/resourceGroups/read
+      notActions: []
+`)
+
+	jsonData := []byte(`{
+  "name": "00000000-0000-0000-0000-000000000001",
+  "type": "Microsoft.Authorization/roleDefinitions",
+  "properties": {
+    "roleName": "Test-Role-Definition",
+    "description": "A test role definition.",
+    "assignableScopes": [
+      "/providers/Microsoft.Management/managementGroups/placeholder"
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Resources/subscriptions/resourceGroups/read"
+        ],
+        "notActions": []
+      }
+    ]
+  }
+}`)
+
+	for _, ext := range []string{".yaml", ".yml"} {
+		t.Run(ext, func(t *testing.T) {
+			rd := new(assets.RoleDefinition)
+			err := NewUnmarshaler(yamlData, ext).Unmarshal(rd)
+			require.NoError(t, err)
+			require.NotNil(t, rd.Properties)
+			require.NotNil(t, rd.Properties.RoleName)
+			assert.Equal(t, "Test-Role-Definition", *rd.Properties.RoleName)
+			require.NotNil(t, rd.Name)
+			assert.Equal(t, "00000000-0000-0000-0000-000000000001", *rd.Name)
+			require.Len(t, rd.Properties.AssignableScopes, 1)
+			assert.Equal(
+				t,
+				"/providers/Microsoft.Management/managementGroups/placeholder",
+				*rd.Properties.AssignableScopes[0],
+			)
+			require.Len(t, rd.Properties.Permissions, 1)
+			require.Len(t, rd.Properties.Permissions[0].Actions, 1)
+		})
+	}
+
+	// The YAML result must be indistinguishable from the JSON result.
+	t.Run("parity with json", func(t *testing.T) {
+		fromYAML := new(assets.RoleDefinition)
+		require.NoError(t, NewUnmarshaler(yamlData, ".yaml").Unmarshal(fromYAML))
+
+		fromJSON := new(assets.RoleDefinition)
+		require.NoError(t, NewUnmarshaler(jsonData, ".json").Unmarshal(fromJSON))
+
+		assert.Equal(t, fromJSON, fromYAML)
+	})
+}
+
+// TestUnmarshalYamlIntoTypedStructPolicyDefinition covers the policy definition asset
+// type, which shares the same unmarshaler and previously had no YAML test coverage.
+func TestUnmarshalYamlIntoTypedStructPolicyDefinition(t *testing.T) {
+	yamlData := []byte(`
+name: test-policy-definition
+type: Microsoft.Authorization/policyDefinitions
+properties:
+  displayName: Test Policy Definition
+  description: A test policy definition.
+  mode: All
+  policyType: Custom
+  metadata:
+    category: Testing
+    version: 1.0.0
+  parameters:
+    effect:
+      type: String
+      defaultValue: Audit
+      allowedValues:
+        - Audit
+        - Deny
+        - Disabled
+  policyRule:
+    if:
+      field: type
+      equals: Microsoft.Storage/storageAccounts
+    then:
+      effect: "[parameters('effect')]"
+`)
+
+	pd := new(assets.PolicyDefinition)
+	require.NoError(t, NewUnmarshaler(yamlData, ".yaml").Unmarshal(pd))
+	require.NotNil(t, pd.Name)
+	assert.Equal(t, "test-policy-definition", *pd.Name)
+	require.NotNil(t, pd.Properties)
+	require.NotNil(t, pd.Properties.DisplayName)
+	assert.Equal(t, "Test Policy Definition", *pd.Properties.DisplayName)
+	require.NotNil(t, pd.Properties.PolicyType)
+	assert.Equal(t, armpolicy.PolicyTypeCustom, *pd.Properties.PolicyType)
+	assert.Contains(t, pd.Properties.Parameters, "effect")
+	assert.NotNil(t, pd.Properties.PolicyRule)
+}
+
+// TestUnmarshalYamlIntoTypedStructPolicySetDefinition covers the policy set definition
+// asset type, which shares the same unmarshaler and previously had no YAML coverage.
+func TestUnmarshalYamlIntoTypedStructPolicySetDefinition(t *testing.T) {
+	yamlData := []byte(`
+name: test-policy-set-definition
+type: Microsoft.Authorization/policySetDefinitions
+properties:
+  displayName: Test Policy Set Definition
+  description: A test policy set definition.
+  policyType: Custom
+  policyDefinitions:
+    - policyDefinitionReferenceId: TestRef
+      policyDefinitionId: /providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/test-policy-definition
+      parameters:
+        effect:
+          value: "[parameters('effect')]"
+  parameters:
+    effect:
+      type: String
+      defaultValue: Audit
+`)
+
+	psd := new(assets.PolicySetDefinition)
+	require.NoError(t, NewUnmarshaler(yamlData, ".yaml").Unmarshal(psd))
+	require.NotNil(t, psd.Name)
+	assert.Equal(t, "test-policy-set-definition", *psd.Name)
+	require.NotNil(t, psd.Properties)
+	require.NotNil(t, psd.Properties.DisplayName)
+	assert.Equal(t, "Test Policy Set Definition", *psd.Properties.DisplayName)
+	require.Len(t, psd.Properties.PolicyDefinitions, 1)
+	require.NotNil(t, psd.Properties.PolicyDefinitions[0].PolicyDefinitionReferenceID)
+	assert.Equal(t, "TestRef", *psd.Properties.PolicyDefinitions[0].PolicyDefinitionReferenceID)
+}
+
+// TestUnmarshalYamlIntoTypedStructPolicyAssignment covers the policy assignment asset
+// type, which shares the same unmarshaler and previously had no YAML coverage.
+func TestUnmarshalYamlIntoTypedStructPolicyAssignment(t *testing.T) {
+	yamlData := []byte(`
+name: test-policy-assignment
+type: Microsoft.Authorization/policyAssignments
+properties:
+  displayName: Test Policy Assignment
+  description: A test policy assignment.
+  policyDefinitionId: /providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/test-policy-set-definition
+  enforcementMode: Default
+  parameters:
+    effect:
+      value: Audit
+`)
+
+	pa := new(assets.PolicyAssignment)
+	require.NoError(t, NewUnmarshaler(yamlData, ".yaml").Unmarshal(pa))
+	require.NotNil(t, pa.Name)
+	assert.Equal(t, "test-policy-assignment", *pa.Name)
+	require.NotNil(t, pa.Properties)
+	require.NotNil(t, pa.Properties.DisplayName)
+	assert.Equal(t, "Test Policy Assignment", *pa.Properties.DisplayName)
+	require.NotNil(t, pa.Properties.PolicyDefinitionID)
+	assert.Contains(t, *pa.Properties.PolicyDefinitionID, "test-policy-set-definition")
+	assert.Contains(t, pa.Properties.Parameters, "effect")
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
## Overview/Summary

Custom role definitions authored in YAML are not loaded by `alzlib`. All fields are
silently discarded during unmarshalling, and the failure surfaces later as a validation
error that does not indicate the underlying cause:

```
no name provided
Failed to initialize AlzLib
```

An equivalent role definition authored in JSON loads correctly, so YAML support is
non-functional in practice despite being documented in `role-definitions.md`:

> "Role definitions can be defined in either JSON or YAML format."

### Root cause

`assets.RoleDefinition` anonymously embeds `armauthorization.RoleDefinition`, which
declares only `json:"..."` struct tags and implements a custom `json.Unmarshaler`. It
carries no `yaml` tags.

`encoding/json` promotes the fields of an anonymously embedded struct automatically;
`gopkg.in/yaml.v3` does not, unless the field is tagged `yaml:",inline"`, and it neither
honours `json` tags nor invokes `json.Unmarshaler`. As a result, `yaml.Unmarshal` could not
map any field of the document onto the destination type. The `properties` block was never
applied and every field retained its zero value. Validation subsequently observed an empty
`roleName` and returned `ErrNoNameProvided` — accurate, but reported far from the point of
failure.

Fixes Azure/Azure-Landing-Zones#4225

## This PR fixes/adds/changes/removes

1. **Reimplements `unmarshalYAML` to route YAML through the JSON decoder.** YAML is decoded
   into an untyped `any`, re-marshalled to JSON, and passed to the existing `unmarshalJSON`
   implementation. Both formats now converge on a single, already-tested decode path, which
   prevents them from diverging again.
2. **Adds `normalizeYAMLToJSON`.** `yaml.v3` decodes a mapping into `map[string]any` only
   when every key is a string; otherwise it yields `map[any]any`, which `encoding/json`
   cannot marshal. This helper recursively converts such keys to strings via `fmt.Sprint`,
   mirroring JSON semantics, where object keys are always strings.
3. **Adds contextual wrapping to errors** returned from the YAML path, so failures identify
   the stage at which they occurred.
4. **Adds six tests** to `internal/processor/unmarshaler_test.go`, covering the reported
   role definition failure, YAML/JSON parity, non-string keys, and regression cover for
   policy definitions, policy set definitions and policy assignments.

### Breaking Changes

`unmarshalYAML` is shared by all asset processors, so the blast radius of this change was
treated as the primary risk and assessed accordingly.

1. **Custom `UnmarshalYAML` implementations are no longer invoked.** Three internal types
   (`libArchetype`, `libArchetypeOverride`, `libArchitecture`) implement `yaml.Unmarshaler`
   and become unreachable now that YAML is routed through JSON. Their behaviour is preserved
   by the JSON path, as evidenced by the existing test suite passing unchanged. They have
   been left in place to keep this change set minimal, and can be removed in a follow-up if
   maintainers prefer.
2. **No other behavioural changes.** Documents that previously parsed correctly continue to
   parse identically. The change is additive in effect: YAML documents that previously
   produced empty structs are now populated correctly.

## Testing Evidence

### Build, tests, vet and lint

| Check | Before the change | After the change |
| --- | --- | --- |
| New tests covering the defect | Fail, reproducing the reported behaviour | Pass |
| `go build ./...` | Pass | Pass |
| `go vet ./...` | Clean | Clean |
| `go test ./...` (all packages) | Pass | Pass |
| `golangci-lint run` | 78 pre-existing findings | 78 findings, identical set; no new findings |

Lint output was compared against a baseline captured on the unmodified tree to confirm that
this change introduces no new findings. The findings are pre-existing and repo-wide:
`go-lint.yml` sets `version: latest`, and `golangci-lint` v2.12 extended `goconst` to
`_test.go` files, so they also appear on unmodified `main`.

### End-to-end verification against an ALZ Accelerator deployment

Because the defect manifests during library initialisation rather than in isolation, it was
also verified at deployment level. Three runs were performed against the same Accelerator
configuration, varying only the role definition file format and the library build:

| Run | Role definition format | Library | Result |
| --- | --- | --- | --- |
| 1 (control) | JSON | Unpatched | Succeeded — `Plan: 1213 to add` |
| 2 (reproduction) | YAML, equivalent content | Unpatched | Failed — `no name provided`, `Failed to initialize AlzLib` |
| 3 (verification) | YAML, equivalent content | Patched | Succeeded — `Plan: 1213 to add` |

Runs 1 and 3 produce an identical Terraform plan, establishing that the change restores
parity between the two formats rather than suppressing the error.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alzlib/pulls)
- [x] Associated it with the relevant [issue](https://github.com/Azure/Azure-Landing-Zones/issues/4225), for tracking and closure
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alzlib/tree/main)
- [x] Performed testing and provided evidence — unit tests, `go vet`, `golangci-lint`, and an end-to-end Accelerator deployment
- [x] Updated relevant and associated documentation — no documentation change is required, as this change aligns the implementation with the documented behaviour